### PR TITLE
Add tiered logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Slowly move original DSL I made over - testing is covered so that helps.
 ### left
 https://grafana.com/docs/loki/latest/configure/#s3_storage_config
 https://square.github.io/kotlinpoet/
+
+## Tiered Logging Example
+
+The `Logger` methods now accept an optional `tier` parameter that adds
+indentation for nested log output.
+
+```kotlin
+val logger = Logger("DSL_BUILDER").enableDebug()
+
+logger.debug("+++ DOMAIN: MyDomain +++")
+logger.debug("package: com.example", tier = 1)
+logger.debug("type: MyDomain", tier = 1)
+logger.debug("Properties", tier = 1)
+logger.debug("myProperty", tier = 2)
+logger.debug("type: kotlin.String", tier = 3)
+```
+

--- a/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
+++ b/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
@@ -60,26 +60,37 @@ class Logger(private val logId: String) {
         warningEnabled = false
     }
 
-    fun info(message: Any) {
-        val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $message")
+    private fun tierPrefix(tier: Int): String {
+        if (tier <= 0) return ""
+
+        val indent = "  ".repeat(tier)
+        return "$indent|__ "
     }
 
-    fun debug(message: Any) {
+    fun info(message: Any, tier: Int = 0) {
+        val id = Logging.ID_TEMPLATE.format(formattedName)
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $prefix$message")
+    }
+
+    fun debug(message: Any, tier: Int = 0) {
         if (!isDebugEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $message")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $prefix$message")
     }
 
-    fun warn(message: Any) {
+    fun warn(message: Any, tier: Int = 0) {
         if (!warningEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$prefix$message${Colors.RESET}")
     }
 
-    fun error(message: Any) {
+    fun error(message: Any, tier: Int = 0) {
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$prefix$message${Colors.RESET}")
     }
 
     // For multi-line logging with consistent indentation


### PR DESCRIPTION
## Summary
- allow specifying a `tier` on logging methods for hierarchical logs
- document new tiered logging usage

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*