### PR TITLE
Add tiered logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ Slowly move original DSL I made over - testing is covered so that helps.
 ### left
 https://grafana.com/docs/loki/latest/configure/#s3_storage_config
 https://square.github.io/kotlinpoet/
+
+## Tiered Logging Example
+
+The `Logger` methods now accept optional `tier` and `branch` parameters.
+`tier` controls the indentation level, while `branch` keeps the vertical
+`|` indicator for nested logs when there are additional sibling entries.
+
+```kotlin
+val logger = Logger("DSL_BUILDER").enableDebug()
+
+logger.debug("+++ DOMAIN: MyDomain +++")
+logger.debug("package: com.example", tier = 1)
+logger.debug("type: MyDomain", tier = 1)
+logger.debug("Properties", tier = 1)
+logger.debug("myProperty", tier = 2)
+logger.debug("type: kotlin.String", tier = 3, branch = true)
+logger.debug("singleEntryTransform: null", tier = 3, branch = true)
+```
+

--- a/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
+++ b/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
@@ -60,26 +60,40 @@ class Logger(private val logId: String) {
         warningEnabled = false
     }
 
-    fun info(message: Any) {
-        val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $message")
+    private fun tierPrefix(tier: Int, branch: Boolean = false): String {
+        if (tier <= 0) return ""
+
+        return if (branch) {
+            "  ".repeat(tier - 1) + "|   |__ "
+        } else {
+            "  ".repeat(tier) + "|__ "
+        }
     }
 
-    fun debug(message: Any) {
+    fun info(message: Any, tier: Int = 0, branch: Boolean = false) {
+        val id = Logging.ID_TEMPLATE.format(formattedName)
+        val prefix = tierPrefix(tier, branch)
+        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $prefix$message")
+    }
+
+    fun debug(message: Any, tier: Int = 0, branch: Boolean = false) {
         if (!isDebugEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $message")
+        val prefix = tierPrefix(tier, branch)
+        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $prefix$message")
     }
 
-    fun warn(message: Any) {
+    fun warn(message: Any, tier: Int = 0, branch: Boolean = false) {
         if (!warningEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier, branch)
+        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$prefix$message${Colors.RESET}")
     }
 
-    fun error(message: Any) {
+    fun error(message: Any, tier: Int = 0, branch: Boolean = false) {
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier, branch)
+        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$prefix$message${Colors.RESET}")
     }
 
     // For multi-line logging with consistent indentation

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
@@ -53,16 +53,16 @@ class BuilderGenerator(
             val domainClassName: ClassName = domain.toClassName()
 
             LOGGER.debug("+++ DOMAIN: $domainClassName  +++")
-            LOGGER.debug("  |__ package: $pkg")
-            LOGGER.debug("  |__ type: $typeName")
-            LOGGER.debug("  |__ builder: $builderName")
+            LOGGER.debug("package: $pkg", tier = 1)
+            LOGGER.debug("type: $typeName", tier = 1)
+            LOGGER.debug("builder: $builderName", tier = 1)
 
             val builderClass: TypeSpec.Builder = TypeSpec.classBuilder(builderName)
                 .addModifiers(KModifier.PUBLIC) // Typically builders are public
 
             // add DSL Marker to the top of the class to restrict scope. Provided by consumer.
             if (dslMarkerClasspath != null) {
-                LOGGER.debug("  |__ DSL Marker added")
+                LOGGER.debug("DSL Marker added", tier = 1)
                 val split = dslMarkerClasspath.split(".")
                 val dslMarkerPackageName = split.subList(0, split.size - 1).joinToString(".")
                 val dslMarkerSimpleName = split.last()
@@ -72,25 +72,21 @@ class BuilderGenerator(
             val dslBuilderInterface = ClassName(dslBuilderClasspath, "DSLBuilder")
             val parameterizedDslBuilder = dslBuilderInterface.parameterizedBy(domainClassName)
             builderClass.addSuperinterface(parameterizedDslBuilder)
-            LOGGER.debug("  |__ DSL Builder Interface added")
+            LOGGER.debug("DSL Builder Interface added", tier = 1)
 
             val constructorParams = mutableListOf<CodeBlock>()
 
 
-            LOGGER.debug("  |__ Properties added")
+            LOGGER.debug("Properties added", tier = 1)
             val lastIndex = domain.getAllProperties().count() - 1
 
             domain.getAllProperties().forEachIndexed { i, prop ->
                 val type = prop.type.toTypeName().copy(nullable = false)
-                val separator = if (LOGGER.debugEnabled() && i != lastIndex) {
-                    "    |"
-                } else {
-                    "     "
-                }
-                LOGGER.debug("      |__ ${prop.simpleName.asString()}")
-                LOGGER.debug("  $separator   |__ type: $type")
+                val branch = i != lastIndex
+                LOGGER.debug(prop.simpleName.asString(), tier = 2)
+                LOGGER.debug("type: $type", tier = 3, branch = branch)
                 val singleEntryTransform = singleEntryTransform[type.toString()]
-                LOGGER.debug("  $separator   |__ singleEntryTransform: $singleEntryTransform")
+                LOGGER.debug("singleEntryTransform: $singleEntryTransform", tier = 3, branch = branch)
 
                 val adapter = DefaultParameterFactoryAdapter(prop, singleEntryTransform)
 


### PR DESCRIPTION
## Summary
- allow specifying `branch` parameter alongside `tier` for nested logs
- use tiered logging in `BuilderGenerator`
- document branch option for tiered logging

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*