### PR TITLE
Use tiered logging in BuilderGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Slowly move original DSL I made over - testing is covered so that helps.
 ### left
 https://grafana.com/docs/loki/latest/configure/#s3_storage_config
 https://square.github.io/kotlinpoet/
+
+## Tiered Logging Example
+
+The `Logger` methods now accept an optional `tier` parameter that adds
+indentation for nested log output.
+
+```kotlin
+val logger = Logger("DSL_BUILDER").enableDebug()
+
+logger.debug("+++ DOMAIN: MyDomain +++")
+logger.debug("package: com.example", tier = 1)
+logger.debug("type: MyDomain", tier = 1)
+logger.debug("Properties", tier = 1)
+logger.debug("myProperty", tier = 2)
+logger.debug("type: kotlin.String", tier = 3)
+```
+

--- a/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
+++ b/common/src/main/kotlin/io/violabs/picard/common/Logging.kt
@@ -60,26 +60,37 @@ class Logger(private val logId: String) {
         warningEnabled = false
     }
 
-    fun info(message: Any) {
-        val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $message")
+    private fun tierPrefix(tier: Int): String {
+        if (tier <= 0) return ""
+
+        val indent = "  ".repeat(tier)
+        return "$indent|__ "
     }
 
-    fun debug(message: Any) {
+    fun info(message: Any, tier: Int = 0) {
+        val id = Logging.ID_TEMPLATE.format(formattedName)
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.INFO} $id ${Logging.DELIMITER} $prefix$message")
+    }
+
+    fun debug(message: Any, tier: Int = 0) {
         if (!isDebugEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $message")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.DEBUG} $id ${Logging.DELIMITER} $prefix$message")
     }
 
-    fun warn(message: Any) {
+    fun warn(message: Any, tier: Int = 0) {
         if (!warningEnabled) return
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.WARN} $id ${Logging.DELIMITER} ${Colors.YELLOW}$prefix$message${Colors.RESET}")
     }
 
-    fun error(message: Any) {
+    fun error(message: Any, tier: Int = 0) {
         val id = Logging.ID_TEMPLATE.format(formattedName)
-        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$message${Colors.RESET}")
+        val prefix = tierPrefix(tier)
+        println("${Logging.LOGO} ${Logging.ERROR} $id ${Logging.DELIMITER} ${Colors.RED}$prefix$message${Colors.RESET}")
     }
 
     // For multi-line logging with consistent indentation

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
@@ -53,16 +53,16 @@ class BuilderGenerator(
             val domainClassName: ClassName = domain.toClassName()
 
             LOGGER.debug("+++ DOMAIN: $domainClassName  +++")
-            LOGGER.debug("  |__ package: $pkg")
-            LOGGER.debug("  |__ type: $typeName")
-            LOGGER.debug("  |__ builder: $builderName")
+            LOGGER.debug("package: $pkg", tier = 1)
+            LOGGER.debug("type: $typeName", tier = 1)
+            LOGGER.debug("builder: $builderName", tier = 1)
 
             val builderClass: TypeSpec.Builder = TypeSpec.classBuilder(builderName)
                 .addModifiers(KModifier.PUBLIC) // Typically builders are public
 
             // add DSL Marker to the top of the class to restrict scope. Provided by consumer.
             if (dslMarkerClasspath != null) {
-                LOGGER.debug("  |__ DSL Marker added")
+                LOGGER.debug("DSL Marker added", tier = 1)
                 val split = dslMarkerClasspath.split(".")
                 val dslMarkerPackageName = split.subList(0, split.size - 1).joinToString(".")
                 val dslMarkerSimpleName = split.last()
@@ -72,29 +72,21 @@ class BuilderGenerator(
             val dslBuilderInterface = ClassName(dslBuilderClasspath, "DSLBuilder")
             val parameterizedDslBuilder = dslBuilderInterface.parameterizedBy(domainClassName)
             builderClass.addSuperinterface(parameterizedDslBuilder)
-            LOGGER.debug("  |__ DSL Builder Interface added")
+            LOGGER.debug("DSL Builder Interface added", tier = 1)
 
             val constructorParams = mutableListOf<CodeBlock>()
 
 
-            LOGGER.debug("  |__ Properties added")
-            val lastIndex = domain.getAllProperties().count() - 1
-
-            domain.getAllProperties().forEachIndexed { i, prop ->
+            LOGGER.debug("Properties added", tier = 1)
+            domain.getAllProperties().forEach { prop ->
                 val type = prop.type.toTypeName().copy(nullable = false)
-                val separator = if (LOGGER.debugEnabled() && i != lastIndex) {
-                    "    |"
-                } else {
-                    "     "
-                }
-                LOGGER.debug("      |__ ${prop.simpleName.asString()}")
-                LOGGER.debug("  $separator   |__ type: $type")
+                LOGGER.debug(prop.simpleName.asString(), tier = 2)
+                LOGGER.debug("type: $type", tier = 3)
                 val singleEntryTransform = singleEntryTransform[type.toString()]
-                LOGGER.debug("  $separator   |__ singleEntryTransform: $singleEntryTransform")
+                LOGGER.debug("singleEntryTransform: $singleEntryTransform", tier = 3)
 
                 val adapter = DefaultParameterFactoryAdapter(prop, singleEntryTransform)
-
-                val dslParam = parameterFactory.determineParam(adapter, i == lastIndex) // Pass logger
+                val dslParam = parameterFactory.determineParam(adapter, false)
 
                 builderClass.addProperty(dslParam.toPropertySpec())
 


### PR DESCRIPTION
## Summary
- switch BuilderGenerator log calls to the new tiered logging API

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*