### PR TITLE
Add tiered logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Slowly move original DSL I made over - testing is covered so that helps.
 ### left
 https://grafana.com/docs/loki/latest/configure/#s3_storage_config
 https://square.github.io/kotlinpoet/
+
+## Tiered Logging Example
+
+The `Logger` methods now accept optional `tier` and `branch` parameters
+that help format nested log output with connecting lines.
+
+```kotlin
+val logger = Logger("DSL_BUILDER").enableDebug()
+
+logger.debug("+++ DOMAIN: MyDomain +++")
+logger.debug("package: com.example", tier = 1, branch = true)
+logger.debug("type: MyDomain", tier = 1, branch = true)
+logger.debug("Properties", tier = 1)
+logger.debug("myProperty", tier = 2, branch = true)
+logger.debug("type: kotlin.String", tier = 3)
+```
+

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/BuilderGenerator.kt
@@ -53,16 +53,16 @@ class BuilderGenerator(
             val domainClassName: ClassName = domain.toClassName()
 
             LOGGER.debug("+++ DOMAIN: $domainClassName  +++")
-            LOGGER.debug("  |__ package: $pkg")
-            LOGGER.debug("  |__ type: $typeName")
-            LOGGER.debug("  |__ builder: $builderName")
+            LOGGER.debug("package: $pkg", tier = 1, branch = true)
+            LOGGER.debug("type: $typeName", tier = 1, branch = true)
+            LOGGER.debug("builder: $builderName", tier = 1, branch = true)
 
             val builderClass: TypeSpec.Builder = TypeSpec.classBuilder(builderName)
                 .addModifiers(KModifier.PUBLIC) // Typically builders are public
 
             // add DSL Marker to the top of the class to restrict scope. Provided by consumer.
             if (dslMarkerClasspath != null) {
-                LOGGER.debug("  |__ DSL Marker added")
+                LOGGER.debug("DSL Marker added", tier = 1, branch = true)
                 val split = dslMarkerClasspath.split(".")
                 val dslMarkerPackageName = split.subList(0, split.size - 1).joinToString(".")
                 val dslMarkerSimpleName = split.last()
@@ -72,25 +72,21 @@ class BuilderGenerator(
             val dslBuilderInterface = ClassName(dslBuilderClasspath, "DSLBuilder")
             val parameterizedDslBuilder = dslBuilderInterface.parameterizedBy(domainClassName)
             builderClass.addSuperinterface(parameterizedDslBuilder)
-            LOGGER.debug("  |__ DSL Builder Interface added")
+            LOGGER.debug("DSL Builder Interface added", tier = 1, branch = true)
 
             val constructorParams = mutableListOf<CodeBlock>()
 
 
-            LOGGER.debug("  |__ Properties added")
+            LOGGER.debug("Properties added", tier = 1)
             val lastIndex = domain.getAllProperties().count() - 1
 
             domain.getAllProperties().forEachIndexed { i, prop ->
                 val type = prop.type.toTypeName().copy(nullable = false)
-                val separator = if (LOGGER.debugEnabled() && i != lastIndex) {
-                    "    |"
-                } else {
-                    "     "
-                }
-                LOGGER.debug("      |__ ${prop.simpleName.asString()}")
-                LOGGER.debug("  $separator   |__ type: $type")
+                val continueBranch = i != lastIndex
+                LOGGER.debug(prop.simpleName.asString(), tier = 2, branch = continueBranch)
+                LOGGER.debug("type: $type", tier = 3, branch = continueBranch)
                 val singleEntryTransform = singleEntryTransform[type.toString()]
-                LOGGER.debug("  $separator   |__ singleEntryTransform: $singleEntryTransform")
+                LOGGER.debug("singleEntryTransform: $singleEntryTransform", tier = 3, branch = continueBranch)
 
                 val adapter = DefaultParameterFactoryAdapter(prop, singleEntryTransform)
 


### PR DESCRIPTION
## Summary
- allow specifying a `tier` on logging methods for hierarchical logs
- add a `branch` flag to maintain vertical connector lines
- update BuilderGenerator to use new tiered logging API
- document new logging parameters in README

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*