### PR TITLE
Add builder documentation comments in DSL functions

### DIFF
--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPFunSpecBuilder.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPFunSpecBuilder.kt
@@ -8,11 +8,16 @@ import com.squareup.kotlinpoet.TypeName
 internal class KPFunSpecBuilder : DefaultParamSpecEnabled() {
     var funName: String? = null
     var returns: TypeName? = null
+    var kdoc: String? = null
     private var overridden: Boolean = false
     private var statements: MutableList<KPStatement> = mutableListOf()
 
     fun override(on: Boolean = true) {
         overridden = on
+    }
+
+    fun kdoc(text: String) {
+        kdoc = text
     }
 
     fun statements(block: KPStatement.Group.() -> Unit) {
@@ -28,6 +33,9 @@ internal class KPFunSpecBuilder : DefaultParamSpecEnabled() {
         }
 
         spec = returns?.let { spec.returns(it) } ?: spec
+
+        if (overridden) spec = spec.addModifiers(KModifier.OVERRIDE)
+        if (kdoc != null) spec = spec.addKdoc(kdoc!!)
 
         for (statement in statements) {
             spec = spec.addStatement(statement.statement, *statement.args.toTypedArray())

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPFunSpecBuilder.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPFunSpecBuilder.kt
@@ -1,6 +1,7 @@
 package io.violabs.picard.dsl.builder
 
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPTypeSpecBuilder.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/builder/KPTypeSpecBuilder.kt
@@ -53,6 +53,8 @@ internal class KPTypeSpecBuilder : DefaultKotlinPoetSpec() {
         var typeBuilder = TypeSpec
             .classBuilder(requireNotNull(name) { "Type - name must be set" })
 
+        superInterface?.let { typeBuilder.addSuperinterface(it) }
+
         for (variable in typeVariables) {
             typeBuilder = typeBuilder.addTypeVariable(variable)
         }

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/params/BuilderParam.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/params/BuilderParam.kt
@@ -8,7 +8,8 @@ class BuilderParam(
     originalPropertyType: TypeName,
     private val nestedBuilderClassName: ClassName,
     override val nullableAssignment: Boolean = true,
-    override val nullableProp: Boolean = true
+    override val nullableProp: Boolean = true,
+    private val kdoc: String? = null
 ) : DSLParam {
     override val propTypeName: TypeName = originalPropertyType
 
@@ -16,6 +17,7 @@ class BuilderParam(
         function {
             add {
                 funName = functionName
+                kdoc?.let { kdoc(it) }
                 param {
                     lambdaType {
                         receiver = nestedBuilderClassName

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/params/BuilderParam.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/params/BuilderParam.kt
@@ -9,15 +9,16 @@ class BuilderParam(
     private val nestedBuilderClassName: ClassName,
     override val nullableAssignment: Boolean = true,
     override val nullableProp: Boolean = true,
-    private val kdoc: String? = null
+    kdoc: String? = null
 ) : DSLParam {
     override val propTypeName: TypeName = originalPropertyType
+    private val _kdoc: String? = kdoc
 
     override fun accessors(): List<FunSpec> = kotlinPoet {
         function {
             add {
                 funName = functionName
-                kdoc?.let { kdoc(it) }
+                _kdoc?.let { kdoc(it) }
                 param {
                     lambdaType {
                         receiver = nestedBuilderClassName

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/params/GroupParam.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/params/GroupParam.kt
@@ -9,7 +9,8 @@ class GroupParam(
     originalPropertyType: TypeName,
     private val builtClassName: ClassName,
     override val nullableAssignment: Boolean = true,
-    override val nullableProp: Boolean = true
+    override val nullableProp: Boolean = true,
+    private val kdoc: String? = null
 ) : DSLParam {
     override val propTypeName: TypeName = originalPropertyType
 
@@ -34,6 +35,7 @@ class GroupParam(
         function {
             add {
                 funName = functionName
+                kdoc?.let { kdoc(it) }
                 param {
                     lambdaType {
                         receiver = receiverName

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/params/MapGroupParam.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/params/MapGroupParam.kt
@@ -10,7 +10,8 @@ class MapGroupParam(
     val mapKeyType: TypeName = STRING,
     val mapValueType: TypeName,
     override val nullableAssignment: Boolean = true,
-    override val nullableProp: Boolean = true
+    override val nullableProp: Boolean = true,
+    private val kdoc: String? = null
 ) : DSLParam {
     override val propTypeName: TypeName = kpMapOf(mapKeyType, mapValueType, nullable = nullableAssignment)
 
@@ -39,6 +40,7 @@ class MapGroupParam(
         function {
             add {
                 funName = functionName
+                kdoc?.let { kdoc(it) }
                 param {
                     lambdaType {
                         receiver = mapGroupClass

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/DefaultParameterFactoryAdapter.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/DefaultParameterFactoryAdapter.kt
@@ -46,15 +46,16 @@ class DefaultParameterFactoryAdapter(
 
     override val hasNullableAssignment: Boolean = resolvedPropKSType.isMarkedNullable
 
-    private val propertyClassDeclaration = resolvedPropKSType.declaration as? KSClassDeclaration
+    private val classDeclarationInternal = resolvedPropKSType.declaration as? KSClassDeclaration
 
-    override val propertyNonNullableClassName: ClassName? = propertyClassDeclaration?.toClassName()
+    override val propertyNonNullableClassName: ClassName? = classDeclarationInternal?.toClassName()
 
-    override val hasGeneratedDSLAnnotation: Boolean = propertyClassDeclaration?.annotations?.any {
+    override val hasGeneratedDSLAnnotation: Boolean = classDeclarationInternal?.annotations?.any {
         it.shortName.asString() == GeneratedDSL::class.simpleName
     } ?: false
 
-    override val propertyClassDeclarationQualifiedName: String? = propertyClassDeclaration?.qualifiedName?.asString()
+    override val propertyClassDeclarationQualifiedName: String? = classDeclarationInternal?.qualifiedName?.asString()
+    override val propertyClassDeclaration: KSClassDeclaration? = classDeclarationInternal
 
     // list only
     private val collectionFirstElementClassDecl = resolvedPropKSType
@@ -84,6 +85,7 @@ class DefaultParameterFactoryAdapter(
         ?: false
 
     override val groupElementClassName: ClassName? = collectionFirstElementClassDecl?.toClassName()
+    override val groupElementClassDeclaration: KSClassDeclaration? = collectionFirstElementClassDecl
 
     private val dslAnnotations: List<KSAnnotation>? = collectionSecondElementClassDecl
         ?.annotations
@@ -100,6 +102,7 @@ class DefaultParameterFactoryAdapter(
     }
 
     override var mapDetails: ParameterFactoryAdapter.MapDetails? = null
+    override val mapValueClassDeclaration: KSClassDeclaration? = collectionSecondElementClassDecl
 
     override fun mapDetails(): ParameterFactoryAdapter.MapDetails? {
         if (mapDetails != null) return mapDetails

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
@@ -172,6 +172,7 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
         val nestedBuilderClassName = ClassName(propertyNonNullableClassName.packageName, nestedBuilderName)
         logger.debug("nestedBuilder: $nestedBuilderClassName", tier = 5, continuous = true)
         val kdoc = builderDoc(nestedBuilderClassName, adapter.propertyClassDeclaration)
+        
         return BuilderParam(
             adapter.propName,
             adapter.actualPropTypeName,
@@ -212,6 +213,7 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
 
     private fun builderDoc(builderClass: ClassName, declaration: KSClassDeclaration?): String? {
         val props = declaration?.getAllProperties()?.map { it.simpleName.asString() }?.toList() ?: return null
+
         if (props.isEmpty()) return null
         val list = props.sorted().joinToString("\n") { "* [${builderClass.simpleName}.$it]" }
         return "Available builder functions:\n$list"

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
@@ -177,7 +177,7 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
             adapter.actualPropTypeName,
             nestedBuilderClassName,
             adapter.hasNullableAssignment,
-            kdoc
+            kdoc = kdoc
         )
     }
 
@@ -193,7 +193,7 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
             adapter.actualPropTypeName,
             groupElementClassName,
             adapter.hasNullableAssignment,
-            kdoc
+            kdoc = kdoc
         )
     }
 
@@ -206,7 +206,7 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
             mapDetails.keyType,
             mapDetails.valueType,
             adapter.hasNullableAssignment,
-            kdoc
+            kdoc = kdoc
         )
     }
 

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactory.kt
@@ -1,6 +1,7 @@
 package io.violabs.picard.dsl.process
 
 import com.squareup.kotlinpoet.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import io.violabs.picard.common.Logger
 import io.violabs.picard.dsl.annotation.GeneratedDSL
 import io.violabs.picard.dsl.params.*
@@ -170,11 +171,13 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
         val nestedBuilderName = propertyNonNullableClassName.simpleName + "Builder"
         val nestedBuilderClassName = ClassName(propertyNonNullableClassName.packageName, nestedBuilderName)
         logger.debug("nestedBuilder: $nestedBuilderClassName", tier = 5, continuous = true)
+        val kdoc = builderDoc(nestedBuilderClassName, adapter.propertyClassDeclaration)
         return BuilderParam(
             adapter.propName,
             adapter.actualPropTypeName,
             nestedBuilderClassName,
-            adapter.hasNullableAssignment
+            adapter.hasNullableAssignment,
+            kdoc
         )
     }
 
@@ -183,23 +186,35 @@ abstract class AbstractParameterFactory<T : ParameterFactoryAdapter, P : Propert
             "Could not determine group element class name."
         }
         logger.debug("listElementClassName: $groupElementClassName", tier = 5, continuous = true)
+        val builderClassName = ClassName(groupElementClassName.packageName, groupElementClassName.simpleName + "Builder")
+        val kdoc = builderDoc(builderClassName, adapter.groupElementClassDeclaration)
         return GroupParam(
             adapter.propName,
             adapter.actualPropTypeName,
             groupElementClassName,
-            adapter.hasNullableAssignment
+            adapter.hasNullableAssignment,
+            kdoc
         )
     }
 
     private fun createMapGroupParam(adapter: T): MapGroupParam {
         val mapDetails = requireNotNull(adapter.mapDetails) { "Please add map details to the map parameter" }
+        val kdoc = builderDoc(mapDetails.valueClass(), adapter.mapValueClassDeclaration)
 
         return MapGroupParam(
             adapter.propName,
             mapDetails.keyType,
             mapDetails.valueType,
-            adapter.hasNullableAssignment
+            adapter.hasNullableAssignment,
+            kdoc
         )
+    }
+
+    private fun builderDoc(builderClass: ClassName, declaration: KSClassDeclaration?): String? {
+        val props = declaration?.getAllProperties()?.map { it.simpleName.asString() }?.toList() ?: return null
+        if (props.isEmpty()) return null
+        val list = props.sorted().joinToString("\n") { "* [${builderClass.simpleName}.$it]" }
+        return "Available builder functions:\n$list"
     }
 
     /**

--- a/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactoryAdapter.kt
+++ b/dsl/src/main/kotlin/io/violabs/picard/dsl/process/ParameterFactoryAdapter.kt
@@ -2,6 +2,7 @@ package io.violabs.picard.dsl.process
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import io.violabs.picard.dsl.annotation.GeneratedDSL
 
 interface ParameterFactoryAdapter {
@@ -14,9 +15,12 @@ interface ParameterFactoryAdapter {
     val propertyNonNullableClassName: ClassName?
     val hasGeneratedDSLAnnotation: Boolean
     val propertyClassDeclarationQualifiedName: String?
+    val propertyClassDeclaration: KSClassDeclaration?
     val isGroupElement: Boolean
     val groupElementClassName: ClassName?
+    val groupElementClassDeclaration: KSClassDeclaration?
     var mapDetails: MapDetails?
+    val mapValueClassDeclaration: KSClassDeclaration?
 
     fun mapDetails(): MapDetails? = null
 

--- a/dsl/src/test/kotlin/io/violabs/picard/dsl/process/ParameterFactoryTest.kt
+++ b/dsl/src/test/kotlin/io/violabs/picard/dsl/process/ParameterFactoryTest.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asTypeName
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import io.violabs.geordi.UnitSim
 import io.violabs.picard.common.Logger
 import io.violabs.picard.dsl.annotation.GeneratedDSL
@@ -84,9 +85,12 @@ class ParameterFactoryTest : UnitSim() {
         override val propertyNonNullableClassName: ClassName? = null
         override val hasGeneratedDSLAnnotation: Boolean = false
         override val propertyClassDeclarationQualifiedName: String? = null
+        override val propertyClassDeclaration: KSClassDeclaration? = null
         override val isGroupElement: Boolean = isGroup
         override val groupElementClassName: ClassName? = ClassName("test", "Example")
+        override val groupElementClassDeclaration: KSClassDeclaration? = null
         override var mapDetails: ParameterFactoryAdapter.MapDetails? = null
+        override val mapValueClassDeclaration: KSClassDeclaration? = null
     }
 
     class TestPropAdapter(


### PR DESCRIPTION
## Summary
- extend `ParameterFactoryAdapter` with class declaration details
- update default adapter to expose class declarations
- generate builder doc comments for builder, group, and map group params
- allow specifying kdoc on KotlinPoet functions
- propagate kdoc through `BuilderParam`, `GroupParam`, and `MapGroupParam`
- adjust tests for new adapter interface

## Testing
- `./gradlew test --offline` *(fails: No route to host)*