### PR TITLE
Add properties to remaining Loki config classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 **/build/**
 .gradle/** 
+
+**/.gradle/**

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/BOSStorageConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/BOSStorageConfig.kt
@@ -1,22 +1,31 @@
 package io.violabs.picard.starCharts.loki
 
-class BOSStorageConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class BOSStorageConfig(
     /**
      * # Name of BOS bucket.
      * # CLI flag: -<prefix>.bos.bucket-name
      * [bucket_name: <string> | default = ""]
-     *
+     */
+    val bucketName: String? = null,
+    /**
      * # BOS endpoint to connect to.
      * # CLI flag: -<prefix>.bos.endpoint
      * [endpoint: <string> | default = "bj.bcebos.com"]
-     *
+     */
+    val endpoint: String? = null,
+    /**
      * # Baidu Cloud Engine (BCE) Access Key ID.
      * # CLI flag: -<prefix>.bos.access-key-id
      * [access_key_id: <string> | default = ""]
-     *
+     */
+    val accessKeyId: String? = null,
+    /**
      * # Baidu Cloud Engine (BCE) Secret Access Key.
      * # CLI flag: -<prefix>.bos.secret-access-key
      * [secret_access_key: <string> | default = ""]
      */
-) {
-}
+    val secretAccessKey: String? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/COSStorageConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/COSStorageConfig.kt
@@ -1,78 +1,83 @@
 package io.violabs.picard.starCharts.loki
 
-class COSStorageConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.cosStorageConfig.BackoffConfig
+import io.violabs.picard.starCharts.loki.cosStorageConfig.HTTPConfig
+
+@GeneratedDSL
+data class COSStorageConfig(
     /**
      * # Set this to `true` to force the request to use path-style addressing.
      * # CLI flag: -<prefix>.cos.force-path-style
      * [forcepathstyle: <boolean> | default = false]
-     *
+     */
+    val forcePathStyle: Boolean? = null,
+    /**
      * # Comma separated list of bucket names to evenly distribute chunks over.
      * # CLI flag: -<prefix>.cos.buckets
      * [bucketnames: <string> | default = ""]
-     *
+     */
+    val bucketNames: String? = null,
+    /**
      * # COS Endpoint to connect to.
      * # CLI flag: -<prefix>.cos.endpoint
      * [endpoint: <string> | default = ""]
-     *
+     */
+    val endpoint: String? = null,
+    /**
      * # COS region to use.
      * # CLI flag: -<prefix>.cos.region
      * [region: <string> | default = ""]
-     *
+     */
+    val region: String? = null,
+    /**
      * # COS HMAC Access Key ID.
      * # CLI flag: -<prefix>.cos.access-key-id
      * [access_key_id: <string> | default = ""]
-     *
+     */
+    val accessKeyId: String? = null,
+    /**
      * # COS HMAC Secret Access Key.
      * # CLI flag: -<prefix>.cos.secret-access-key
      * [secret_access_key: <string> | default = ""]
-     *
-     * http_config:
-     *   # The maximum amount of time an idle connection will be held open.
-     *   # CLI flag: -<prefix>.cos.http.idle-conn-timeout
-     *   [idle_conn_timeout: <duration> | default = 1m30s]
-     *
-     *   # If non-zero, specifies the amount of time to wait for a server's response
-     *   # headers after fully writing the request.
-     *   # CLI flag: -<prefix>.cos.http.response-header-timeout
-     *   [response_header_timeout: <duration> | default = 0s]
-     *
-     * # Configures back off when cos get Object.
-     * backoff_config:
-     *   # Minimum backoff time when cos get Object.
-     *   # CLI flag: -<prefix>.cos.min-backoff
-     *   [min_period: <duration> | default = 100ms]
-     *
-     *   # Maximum backoff time when cos get Object.
-     *   # CLI flag: -<prefix>.cos.max-backoff
-     *   [max_period: <duration> | default = 3s]
-     *
-     *   # Maximum number of times to retry when cos get Object.
-     *   # CLI flag: -<prefix>.cos.max-retries
-     *   [max_retries: <int> | default = 5]
-     *
+     */
+    val secretAccessKey: String? = null,
+    val httpConfig: HTTPConfig? = null,
+    val backoffConfig: BackoffConfig? = null,
+    /**
      * # IAM API key to access COS.
      * # CLI flag: -<prefix>.cos.api-key
      * [api_key: <string> | default = ""]
-     *
+     */
+    val apiKey: String? = null,
+    /**
      * # COS service instance id to use.
      * # CLI flag: -<prefix>.cos.service-instance-id
      * [service_instance_id: <string> | default = ""]
-     *
+     */
+    val serviceInstanceId: String? = null,
+    /**
      * # IAM Auth Endpoint for authentication.
      * # CLI flag: -<prefix>.cos.auth-endpoint
      * [auth_endpoint: <string> | default = "https://iam.cloud.ibm.com/identity/token"]
-     *
+     */
+    val authEndpoint: String? = null,
+    /**
      * # Compute resource token file path.
      * # CLI flag: -<prefix>.cos.cr-token-file-path
      * [cr_token_file_path: <string> | default = ""]
-     *
+     */
+    val crTokenFilePath: String? = null,
+    /**
      * # Name of the trusted profile.
      * # CLI flag: -<prefix>.cos.trusted-profile-name
      * [trusted_profile_name: <string> | default = ""]
-     *
+     */
+    val trustedProfileName: String? = null,
+    /**
      * # ID of the trusted profile.
      * # CLI flag: -<prefix>.cos.trusted-profile-id
      * [trusted_profile_id: <string> | default = ""]
      */
-) {
-}
+    val trustedProfileId: String? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/CacheConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/CacheConfig.kt
@@ -1,173 +1,18 @@
 package io.violabs.picard.starCharts.loki
 
-class CacheConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class CacheConfig(
     /**
      * # The default validity of entries for caches unless overridden.
      * # CLI flag: -<prefix>.default-validity
      * [default_validity: <duration> | default = 1h]
-     *
-     * background:
-     *   # At what concurrency to write back to cache.
-     *   # CLI flag: -<prefix>.background.write-back-concurrency
-     *   [writeback_goroutines: <int> | default = 1]
-     *
-     *   # How many key batches to buffer for background write-back. Default is large
-     *   # to prefer size based limiting.
-     *   # CLI flag: -<prefix>.background.write-back-buffer
-     *   [writeback_buffer: <int> | default = 500000]
-     *
-     *   # Size limit in bytes for background write-back.
-     *   # CLI flag: -<prefix>.background.write-back-size-limit
-     *   [writeback_size_limit: <int> | default = 500MB]
-     *
-     * memcached:
-     *   # How long keys stay in the memcache.
-     *   # CLI flag: -<prefix>.memcached.expiration
-     *   [expiration: <duration> | default = 0s]
-     *
-     *   # How many keys to fetch in each batch.
-     *   # CLI flag: -<prefix>.memcached.batchsize
-     *   [batch_size: <int> | default = 4]
-     *
-     *   # Maximum active requests to memcache.
-     *   # CLI flag: -<prefix>.memcached.parallelism
-     *   [parallelism: <int> | default = 5]
-     *
-     * memcached_client:
-     *   # Hostname for memcached service to use. If empty and if addresses is unset,
-     *   # no memcached will be used.
-     *   # CLI flag: -<prefix>.memcached.hostname
-     *   [host: <string> | default = ""]
-     *
-     *   # SRV service used to discover memcache servers.
-     *   # CLI flag: -<prefix>.memcached.service
-     *   [service: <string> | default = "memcached"]
-     *
-     *   # Comma separated addresses list in DNS Service Discovery format:
-     *   # https://grafana.com/docs/mimir/latest/configure/about-dns-service-discovery/#supported-discovery-modes
-     *   # CLI flag: -<prefix>.memcached.addresses
-     *   [addresses: <string> | default = ""]
-     *
-     *   # Maximum time to wait before giving up on memcached requests.
-     *   # CLI flag: -<prefix>.memcached.timeout
-     *   [timeout: <duration> | default = 100ms]
-     *
-     *   # Maximum number of idle connections in pool.
-     *   # CLI flag: -<prefix>.memcached.max-idle-conns
-     *   [max_idle_conns: <int> | default = 16]
-     *
-     *   # The maximum size of an item stored in memcached. Bigger items are not
-     *   # stored. If set to 0, no maximum size is enforced.
-     *   # CLI flag: -<prefix>.memcached.max-item-size
-     *   [max_item_size: <int> | default = 0]
-     *
-     *   # Period with which to poll DNS for memcache servers.
-     *   # CLI flag: -<prefix>.memcached.update-interval
-     *   [update_interval: <duration> | default = 1m]
-     *
-     *   # Use consistent hashing to distribute to memcache servers.
-     *   # CLI flag: -<prefix>.memcached.consistent-hash
-     *   [consistent_hash: <boolean> | default = true]
-     *
-     *   # Trip circuit-breaker after this number of consecutive dial failures (if zero
-     *   # then circuit-breaker is disabled).
-     *   # CLI flag: -<prefix>.memcached.circuit-breaker-consecutive-failures
-     *   [circuit_breaker_consecutive_failures: <int> | default = 10]
-     *
-     *   # Duration circuit-breaker remains open after tripping (if zero then 60
-     *   # seconds is used).
-     *   # CLI flag: -<prefix>.memcached.circuit-breaker-timeout
-     *   [circuit_breaker_timeout: <duration> | default = 10s]
-     *
-     *   # Reset circuit-breaker counts after this long (if zero then never reset).
-     *   # CLI flag: -<prefix>.memcached.circuit-breaker-interval
-     *   [circuit_breaker_interval: <duration> | default = 10s]
-     *
-     *   # Enable connecting to Memcached with TLS.
-     *   # CLI flag: -<prefix>.memcached.tls-enabled
-     *   [tls_enabled: <boolean> | default = false]
-     *
-     *   # The TLS configuration.
-     *   # The CLI flags prefix for this block configuration is:
-     *   # store.index-cache-write.memcached
-     *   [<tls_config>]
-     *
-     * redis:
-     *   # Redis Server or Cluster configuration endpoint to use for caching. A
-     *   # comma-separated list of endpoints for Redis Cluster or Redis Sentinel. If
-     *   # empty, no redis will be used.
-     *   # CLI flag: -<prefix>.redis.endpoint
-     *   [endpoint: <string> | default = ""]
-     *
-     *   # Redis Sentinel master name. An empty string for Redis Server or Redis
-     *   # Cluster.
-     *   # CLI flag: -<prefix>.redis.master-name
-     *   [master_name: <string> | default = ""]
-     *
-     *   # Maximum time to wait before giving up on redis requests.
-     *   # CLI flag: -<prefix>.redis.timeout
-     *   [timeout: <duration> | default = 500ms]
-     *
-     *   # How long keys stay in the redis.
-     *   # CLI flag: -<prefix>.redis.expiration
-     *   [expiration: <duration> | default = 0s]
-     *
-     *   # Database index.
-     *   # CLI flag: -<prefix>.redis.db
-     *   [db: <int> | default = 0]
-     *
-     *   # Maximum number of connections in the pool.
-     *   # CLI flag: -<prefix>.redis.pool-size
-     *   [pool_size: <int> | default = 0]
-     *
-     *   # Username to use when connecting to redis.
-     *   # CLI flag: -<prefix>.redis.username
-     *   [username: <string> | default = ""]
-     *
-     *   # Password to use when connecting to redis.
-     *   # CLI flag: -<prefix>.redis.password
-     *   [password: <string> | default = ""]
-     *
-     *   # Enable connecting to redis with TLS.
-     *   # CLI flag: -<prefix>.redis.tls-enabled
-     *   [tls_enabled: <boolean> | default = false]
-     *
-     *   # Skip validating server certificate.
-     *   # CLI flag: -<prefix>.redis.tls-insecure-skip-verify
-     *   [tls_insecure_skip_verify: <boolean> | default = false]
-     *
-     *   # Close connections after remaining idle for this duration. If the value is
-     *   # zero, then idle connections are not closed.
-     *   # CLI flag: -<prefix>.redis.idle-timeout
-     *   [idle_timeout: <duration> | default = 0s]
-     *
-     *   # Close connections older than this duration. If the value is zero, then the
-     *   # pool does not close connections based on age.
-     *   # CLI flag: -<prefix>.redis.max-connection-age
-     *   [max_connection_age: <duration> | default = 0s]
-     *
-     *   # By default, the Redis client only reads from the master node. Enabling this
-     *   # option can lower pressure on the master node by randomly routing read-only
-     *   # commands to the master and any available replicas.
-     *   # CLI flag: -<prefix>.redis.route-randomly
-     *   [route_randomly: <boolean> | default = false]
-     *
-     * embedded_cache:
-     *   # Whether embedded cache is enabled.
-     *   # CLI flag: -<prefix>.embedded-cache.enabled
-     *   [enabled: <boolean> | default = false]
-     *
-     *   # Maximum memory size of the cache in MB.
-     *   # CLI flag: -<prefix>.embedded-cache.max-size-mb
-     *   [max_size_mb: <int> | default = 100]
-     *
-     *   # Maximum number of entries in the cache.
-     *   # CLI flag: -<prefix>.embedded-cache.max-size-items
-     *   [max_size_items: <int> | default = 0]
-     *
-     *   # The time to live for items in the cache before they get purged.
-     *   # CLI flag: -<prefix>.embedded-cache.ttl
-     *   [ttl: <duration> | default = 1h]
      */
-) {
-}
+    val defaultValidity: Duration? = null,
+    val background: cacheConfig.Background? = null,
+    val memcached: cacheConfig.Memcached? = null,
+    val memcachedClient: cacheConfig.MemcachedClient? = null,
+    val redis: cacheConfig.Redis? = null,
+    val embeddedCache: cacheConfig.EmbeddedCache? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/ChunkStorageConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/ChunkStorageConfig.kt
@@ -1,37 +1,50 @@
 package io.violabs.picard.starCharts.loki
 
-class ChunkStorageConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class ChunkStorageConfig(
     /**
      * # The cache_config block configures the cache backend for a specific Loki
      * # component.
      * # The CLI flags prefix for this block configuration is: store.chunks-cache
      * [chunk_cache_config: <cache_config>]
-     *
+     */
+    val chunkCacheConfig: CacheConfig? = null,
+    /**
      * # The cache_config block configures the cache backend for a specific Loki
      * # component.
      * # The CLI flags prefix for this block configuration is: store.chunks-cache-l2
      * [chunk_cache_config_l2: <cache_config>]
-     *
+     */
+    val chunkCacheConfigL2: CacheConfig? = null,
+    /**
      * # Write dedupe cache is deprecated along with legacy index types (aws,
      * # aws-dynamo, bigtable, bigtable-hashed, cassandra, gcp, gcp-columnkey,
      * # grpc-store).
      * # Consider using TSDB index which does not require a write dedupe cache.
      * # The CLI flags prefix for this block configuration is: store.index-cache-write
      * [write_dedupe_cache_config: <cache_config>]
-     *
+     */
+    val writeDedupeCacheConfig: CacheConfig? = null,
+    /**
      * # Chunks fetched from queriers before this duration will not be written to the
      * # cache. A value of 0 will write all chunks to the cache
      * # CLI flag: -store.skip-query-writeback-older-than
      * [skip_query_writeback_cache_older_than: <duration> | default = 0s]
-     *
+     */
+    val skipQueryWritebackCacheOlderThan: Duration? = null,
+    /**
      * # Chunks will be handed off to the L2 cache after this duration. 0 to disable L2
      * # cache.
      * # CLI flag: -store.chunks-cache-l2.handoff
      * [l2_chunk_cache_handoff: <duration> | default = 0s]
-     *
+     */
+    val l2ChunkCacheHandoff: Duration? = null,
+    /**
      * # Cache index entries older than this period. 0 to disable.
      * # CLI flag: -store.cache-lookups-older-than
      * [cache_lookups_older_than: <duration> | default = 0s]
      */
-) {
-}
+    val cacheLookupsOlderThan: Duration? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Consul.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Consul.kt
@@ -1,35 +1,51 @@
 package io.violabs.picard.starCharts.loki
 
-class Consul(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class Consul(
     /**
      * # Hostname and port of Consul.
      * # CLI flag: -<prefix>.consul.hostname
      * [host: <string> | default = "localhost:8500"]
-     *
+     */
+    val host: String? = null,
+    /**
      * # ACL Token used to interact with Consul.
      * # CLI flag: -<prefix>.consul.acl-token
      * [acl_token: <string> | default = ""]
-     *
+     */
+    val aclToken: String? = null,
+    /**
      * # HTTP timeout when talking to Consul
      * # CLI flag: -<prefix>.consul.client-timeout
      * [http_client_timeout: <duration> | default = 20s]
-     *
+     */
+    val httpClientTimeout: Duration? = null,
+    /**
      * # Enable consistent reads to Consul.
      * # CLI flag: -<prefix>.consul.consistent-reads
      * [consistent_reads: <boolean> | default = false]
-     *
+     */
+    val consistentReads: Boolean? = null,
+    /**
      * # Rate limit when watching key or prefix in Consul, in requests per second. 0
      * # disables the rate limit.
      * # CLI flag: -<prefix>.consul.watch-rate-limit
      * [watch_rate_limit: <float> | default = 1]
-     *
+     */
+    val watchRateLimit: Float? = null,
+    /**
      * # Burst size used in rate limit. Values less than 1 are treated as 1.
      * # CLI flag: -<prefix>.consul.watch-burst-size
      * [watch_burst_size: <int> | default = 1]
-     *
+     */
+    val watchBurstSize: Int? = null,
+    /**
      * # Maximum duration to wait before retrying a Compare And Swap (CAS) operation.
      * # CLI flag: -<prefix>.consul.cas-retry-delay
      * [cas_retry_delay: <duration> | default = 1s]
      */
-) {
-}
+    val casRetryDelay: Duration? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/ETCD.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/ETCD.kt
@@ -1,34 +1,51 @@
 package io.violabs.picard.starCharts.loki
 
-class ETCD(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+import io.violabs.picard.starCharts.loki.tls.TLSConfig
+
+@GeneratedDSL
+data class ETCD(
     /**
      * # The etcd endpoints to connect to.
      * # CLI flag: -<prefix>.etcd.endpoints
      * [endpoints: <list of strings> | default = []]
-     *
+     */
+    val endpoints: List<String>? = null,
+    /**
      * # The dial timeout for the etcd connection.
      * # CLI flag: -<prefix>.etcd.dial-timeout
      * [dial_timeout: <duration> | default = 10s]
-     *
+     */
+    val dialTimeout: Duration? = null,
+    /**
      * # The maximum number of retries to do for failed ops.
      * # CLI flag: -<prefix>.etcd.max-retries
      * [max_retries: <int> | default = 10]
-     *
+     */
+    val maxRetries: Int? = null,
+    /**
      * # Enable TLS.
      * # CLI flag: -<prefix>.etcd.tls-enabled
      * [tls_enabled: <boolean> | default = false]
-     *
+     */
+    val tlsEnabled: Boolean? = null,
+    /**
      * # The TLS configuration.
      * # The CLI flags prefix for this block configuration is: ruler.ring.etcd
      * [<tls_config>]
-     *
+     */
+    val tlsConfig: TLSConfig? = null,
+    /**
      * # Etcd username.
      * # CLI flag: -<prefix>.etcd.username
      * [username: <string> | default = ""]
-     *
+     */
+    val username: String? = null,
+    /**
      * # Etcd password.
      * # CLI flag: -<prefix>.etcd.password
      * [password: <string> | default = ""]
      */
-) {
-}
+    val password: String? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/FrontendWorker.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/FrontendWorker.kt
@@ -1,6 +1,11 @@
 package io.violabs.picard.starCharts.loki
 
-class FrontendWorker(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+import io.violabs.picard.starCharts.loki.GRPCClient
+
+@GeneratedDSL
+data class FrontendWorker(
     /**
      * # Address of query frontend service, in host:port format. If
      * # -querier.scheduler-address is set as well, querier will use scheduler instead.
@@ -8,42 +13,54 @@ class FrontendWorker(
      * # set. If neither is set, queries are only received via HTTP endpoint.
      * # CLI flag: -querier.frontend-address
      * [frontend_address: <string> | default = ""]
-     *
+     */
+    val frontendAddress: String? = null,
+    /**
      * # Hostname (and port) of scheduler that querier will periodically resolve,
      * # connect to and receive queries from. Only one of -querier.frontend-address or
      * # -querier.scheduler-address can be set. If neither is set, queries are only
      * # received via HTTP endpoint.
      * # CLI flag: -querier.scheduler-address
      * [scheduler_address: <string> | default = ""]
-     *
+     */
+    val schedulerAddress: String? = null,
+    /**
      * # How often to query DNS for query-frontend or query-scheduler address. Also
      * # used to determine how often to poll the scheduler-ring for addresses if the
      * # scheduler-ring is configured.
      * # CLI flag: -querier.dns-lookup-period
      * [dns_lookup_duration: <duration> | default = 3s]
-     *
+     */
+    val dnsLookupDuration: Duration? = null,
+    /**
      * # Querier ID, sent to frontend service to identify requests from the same
      * # querier. Defaults to hostname.
      * # CLI flag: -querier.id
      * [id: <string> | default = ""]
-     *
+     */
+    val id: String? = null,
+    /**
      * # Configures the querier gRPC client used to communicate with the
      * # query-frontend. This can't be used in conjunction with 'grpc_client_config'.
      * # The CLI flags prefix for this block configuration is:
      * # querier.frontend-grpc-client
      * [query_frontend_grpc_client: <grpc_client>]
-     *
+     */
+    val queryFrontendGrpcClient: GRPCClient? = null,
+    /**
      * # Configures the querier gRPC client used to communicate with the query-frontend
      * # and with the query-scheduler. This can't be used in conjunction with
      * # 'query_frontend_grpc_client' or 'query_scheduler_grpc_client'.
      * # The CLI flags prefix for this block configuration is: querier.frontend-client
      * [grpc_client_config: <grpc_client>]
-     *
+     */
+    val grpcClientConfig: GRPCClient? = null,
+    /**
      * # Configures the querier gRPC client used to communicate with the
      * # query-scheduler. This can't be used in conjunction with 'grpc_client_config'.
      * # The CLI flags prefix for this block configuration is:
      * # querier.scheduler-grpc-client
      * [query_scheduler_grpc_client: <grpc_client>]
      */
-) {
-}
+    val querySchedulerGrpcClient: GRPCClient? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/GCSStorageConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/GCSStorageConfig.kt
@@ -1,43 +1,61 @@
 package io.violabs.picard.starCharts.loki
 
-class GCSStorageConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class GCSStorageConfig(
     /**
      * # Name of GCS bucket. Please refer to
      * # https://cloud.google.com/docs/authentication/production for more information
      * # about how to configure authentication.
      * # CLI flag: -<prefix>.gcs.bucketname
      * [bucket_name: <string> | default = ""]
-     *
+     */
+    val bucketName: String? = null,
+    /**
      * # Custom GCS endpoint URL.
      * # CLI flag: -<prefix>.gcs.endpoint
      * [endpoint: <string> | default = ""]
-     *
+     */
+    val endpoint: String? = null,
+    /**
      * # Service account key content in JSON format, refer to
      * # https://cloud.google.com/iam/docs/creating-managing-service-account-keys for
      * # creation.
      * # CLI flag: -<prefix>.gcs.service-account
      * [service_account: <string> | default = ""]
-     *
+     */
+    val serviceAccount: String? = null,
+    /**
      * # The size of the buffer that GCS client for each PUT request. 0 to disable
      * # buffering.
      * # CLI flag: -<prefix>.gcs.chunk-buffer-size
      * [chunk_buffer_size: <int> | default = 0]
-     *
+     */
+    val chunkBufferSize: Int? = null,
+    /**
      * # The duration after which the requests to GCS should be timed out.
      * # CLI flag: -<prefix>.gcs.request-timeout
      * [request_timeout: <duration> | default = 0s]
-     *
+     */
+    val requestTimeout: Duration? = null,
+    /**
      * # Enable OpenCensus (OC) instrumentation for all requests.
      * # CLI flag: -<prefix>.gcs.enable-opencensus
      * [enable_opencensus: <boolean> | default = true]
-     *
+     */
+    val enableOpencensus: Boolean? = null,
+    /**
      * # Enable HTTP2 connections.
      * # CLI flag: -<prefix>.gcs.enable-http2
      * [enable_http2: <boolean> | default = true]
-     *
+     */
+    val enableHttp2: Boolean? = null,
+    /**
      * # Enable automatic retries of failed idempotent requests.
      * # CLI flag: -<prefix>.gcs.enable-retries
      * [enable_retries: <boolean> | default = true]
      */
-) {
-}
+    val enableRetries: Boolean? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/IndexGateway.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/IndexGateway.kt
@@ -1,6 +1,9 @@
 package io.violabs.picard.starCharts.loki
 
-class IndexGateway(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class IndexGateway(
     /**
      * # Defines in which mode the index gateway server will operate (default to
      * # 'simple'). It supports two modes:
@@ -10,98 +13,13 @@ class IndexGateway(
      * # tenants instead of all tenants.
      * # CLI flag: -index-gateway.mode
      * [mode: <string> | default = "simple"]
-     *
+     */
+    val mode: String? = null,
+    /**
      * # Defines the ring to be used by the index gateway servers and clients in case
      * # the servers are configured to run in 'ring' mode. In case this isn't
      * # configured, this block supports inheriting configuration from the common ring
      * # section.
-     * ring:
-     *   kvstore:
-     *     # Backend storage to use for the ring. Supported values are: consul, etcd,
-     *     # inmemory, memberlist, multi.
-     *     # CLI flag: -index-gateway.ring.store
-     *     [store: <string> | default = "consul"]
-     *
-     *     # The prefix for the keys in the store. Should end with a /.
-     *     # CLI flag: -index-gateway.ring.prefix
-     *     [prefix: <string> | default = "collectors/"]
-     *
-     *     # Configuration for a Consul client. Only applies if the selected kvstore is
-     *     # consul.
-     *     # The CLI flags prefix for this block configuration is: index-gateway.ring
-     *     [consul: <consul>]
-     *
-     *     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
-     *     # is etcd.
-     *     # The CLI flags prefix for this block configuration is: index-gateway.ring
-     *     [etcd: <etcd>]
-     *
-     *     multi:
-     *       # Primary backend storage used by multi-client.
-     *       # CLI flag: -index-gateway.ring.multi.primary
-     *       [primary: <string> | default = ""]
-     *
-     *       # Secondary backend storage used by multi-client.
-     *       # CLI flag: -index-gateway.ring.multi.secondary
-     *       [secondary: <string> | default = ""]
-     *
-     *       # Mirror writes to secondary store.
-     *       # CLI flag: -index-gateway.ring.multi.mirror-enabled
-     *       [mirror_enabled: <boolean> | default = false]
-     *
-     *       # Timeout for storing value to secondary store.
-     *       # CLI flag: -index-gateway.ring.multi.mirror-timeout
-     *       [mirror_timeout: <duration> | default = 2s]
-     *
-     *   # Period at which to heartbeat to the ring. 0 = disabled.
-     *   # CLI flag: -index-gateway.ring.heartbeat-period
-     *   [heartbeat_period: <duration> | default = 15s]
-     *
-     *   # The heartbeat timeout after which compactors are considered unhealthy within
-     *   # the ring. 0 = never (timeout disabled).
-     *   # CLI flag: -index-gateway.ring.heartbeat-timeout
-     *   [heartbeat_timeout: <duration> | default = 1m]
-     *
-     *   # File path where tokens are stored. If empty, tokens are not stored at
-     *   # shutdown and restored at startup.
-     *   # CLI flag: -index-gateway.ring.tokens-file-path
-     *   [tokens_file_path: <string> | default = ""]
-     *
-     *   # True to enable zone-awareness and replicate blocks across different
-     *   # availability zones.
-     *   # CLI flag: -index-gateway.ring.zone-awareness-enabled
-     *   [zone_awareness_enabled: <boolean> | default = false]
-     *
-     *   # Deprecated: How many index gateway instances are assigned to each tenant.
-     *   # Use -index-gateway.shard-size instead. The shard size is also a per-tenant
-     *   # setting.
-     *   # CLI flag: -replication-factor
-     *   [replication_factor: <int> | default = 3]
-     *
-     *   # Instance ID to register in the ring.
-     *   # CLI flag: -index-gateway.ring.instance-id
-     *   [instance_id: <string> | default = "<hostname>"]
-     *
-     *   # Name of network interface to read address from.
-     *   # CLI flag: -index-gateway.ring.instance-interface-names
-     *   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
-     *
-     *   # Port to advertise in the ring (defaults to server.grpc-listen-port).
-     *   # CLI flag: -index-gateway.ring.instance-port
-     *   [instance_port: <int> | default = 0]
-     *
-     *   # IP address to advertise in the ring.
-     *   # CLI flag: -index-gateway.ring.instance-addr
-     *   [instance_addr: <string> | default = ""]
-     *
-     *   # The availability zone where this instance is running. Required if
-     *   # zone-awareness is enabled.
-     *   # CLI flag: -index-gateway.ring.instance-availability-zone
-     *   [instance_availability_zone: <string> | default = ""]
-     *
-     *   # Enable using a IPv6 instance address.
-     *   # CLI flag: -index-gateway.ring.instance-enable-ipv6
-     *   [instance_enable_ipv6: <boolean> | default = false]
      */
-) {
-}
+    val ring: indexGateway.Ring? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/LocalStorageConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/LocalStorageConfig.kt
@@ -1,10 +1,13 @@
 package io.violabs.picard.starCharts.loki
 
-class LocalStorageConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class LocalStorageConfig(
     /**
      * # Directory to store chunks in.
      * # CLI flag: -local.chunk-directory
      * [directory: <string> | default = ""]
      */
-) {
-}
+    val directory: String? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/OperationalConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/OperationalConfig.kt
@@ -1,34 +1,47 @@
 package io.violabs.picard.starCharts.loki
 
-class OperationalConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class OperationalConfig(
     /**
      * # Log every new stream created by a push request (very verbose, recommend to
      * # enable via runtime config only).
      * # CLI flag: -operation-config.log-stream-creation
      * [log_stream_creation: <boolean> | default = false]
-     *
+     */
+    val logStreamCreation: Boolean? = null,
+    /**
      * # Log every push request (very verbose, recommend to enable via runtime config
      * # only).
      * # CLI flag: -operation-config.log-push-request
      * [log_push_request: <boolean> | default = false]
-     *
+     */
+    val logPushRequest: Boolean? = null,
+    /**
      * # Log every stream in a push request (very verbose, recommend to enable via
      * # runtime config only).
      * # CLI flag: -operation-config.log-push-request-streams
      * [log_push_request_streams: <boolean> | default = false]
-     *
+     */
+    val logPushRequestStreams: Boolean? = null,
+    /**
      * # Log metrics for duplicate lines received.
      * # CLI flag: -operation-config.log-duplicate-metrics
      * [log_duplicate_metrics: <boolean> | default = false]
-     *
+     */
+    val logDuplicateMetrics: Boolean? = null,
+    /**
      * # Log stream info for duplicate lines received
      * # CLI flag: -operation-config.log-duplicate-stream-info
      * [log_duplicate_stream_info: <boolean> | default = false]
-     *
+     */
+    val logDuplicateStreamInfo: Boolean? = null,
+    /**
      * # Log push errors with a rate limited logger, will show client push errors
      * # without overly spamming logs.
      * # CLI flag: -operation-config.limited-log-push-errors
      * [limited_log_push_errors: <boolean> | default = true]
      */
-) {
-}
+    val limitedLogPushErrors: Boolean? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/QueryScheduler.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/QueryScheduler.kt
@@ -1,120 +1,52 @@
 package io.violabs.picard.starCharts.loki
 
-class QueryScheduler(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class QueryScheduler(
     /**
      * # Maximum number of outstanding requests per tenant per query-scheduler.
      * # In-flight requests above this limit will fail with HTTP response status code
      * # 429.
      * # CLI flag: -query-scheduler.max-outstanding-requests-per-tenant
      * [max_outstanding_requests_per_tenant: <int> | default = 32000]
-     *
+     */
+    val maxOutstandingRequestsPerTenant: Int? = null,
+    /**
      * # Maximum number of levels of nesting of hierarchical queues. 0 means that
      * # hierarchical queues are disabled.
      * # CLI flag: -query-scheduler.max-queue-hierarchy-levels
      * [max_queue_hierarchy_levels: <int> | default = 3]
-     *
+     */
+    val maxQueueHierarchyLevels: Int? = null,
+    /**
      * # If a querier disconnects without sending notification about graceful shutdown,
      * # the query-scheduler will keep the querier in the tenant's shard until the
      * # forget delay has passed. This feature is useful to reduce the blast radius
      * # when shuffle-sharding is enabled.
      * # CLI flag: -query-scheduler.querier-forget-delay
      * [querier_forget_delay: <duration> | default = 0s]
-     *
+     */
+    val querierForgetDelay: Duration? = null,
+    /**
      * # This configures the gRPC client used to report errors back to the
      * # query-frontend.
      * # The CLI flags prefix for this block configuration is:
      * # query-scheduler.grpc-client-config
      * [grpc_client_config: <grpc_client>]
-     *
+     */
+    val grpcClientConfig: GRPCClient? = null,
+    /**
      * # Set to true to have the query schedulers create and place themselves in a
      * # ring. If no frontend_address or scheduler_address are present anywhere else in
      * # the configuration, Loki will toggle this value to true.
      * # CLI flag: -query-scheduler.use-scheduler-ring
      * [use_scheduler_ring: <boolean> | default = false]
-     *
+     */
+    val useSchedulerRing: Boolean? = null,
+    /**
      * # The hash ring configuration. This option is required only if
      * # use_scheduler_ring is true.
-     * scheduler_ring:
-     *   kvstore:
-     *     # Backend storage to use for the ring. Supported values are: consul, etcd,
-     *     # inmemory, memberlist, multi.
-     *     # CLI flag: -query-scheduler.ring.store
-     *     [store: <string> | default = "consul"]
-     *
-     *     # The prefix for the keys in the store. Should end with a /.
-     *     # CLI flag: -query-scheduler.ring.prefix
-     *     [prefix: <string> | default = "collectors/"]
-     *
-     *     # Configuration for a Consul client. Only applies if the selected kvstore is
-     *     # consul.
-     *     # The CLI flags prefix for this block configuration is: query-scheduler.ring
-     *     [consul: <consul>]
-     *
-     *     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
-     *     # is etcd.
-     *     # The CLI flags prefix for this block configuration is: query-scheduler.ring
-     *     [etcd: <etcd>]
-     *
-     *     multi:
-     *       # Primary backend storage used by multi-client.
-     *       # CLI flag: -query-scheduler.ring.multi.primary
-     *       [primary: <string> | default = ""]
-     *
-     *       # Secondary backend storage used by multi-client.
-     *       # CLI flag: -query-scheduler.ring.multi.secondary
-     *       [secondary: <string> | default = ""]
-     *
-     *       # Mirror writes to secondary store.
-     *       # CLI flag: -query-scheduler.ring.multi.mirror-enabled
-     *       [mirror_enabled: <boolean> | default = false]
-     *
-     *       # Timeout for storing value to secondary store.
-     *       # CLI flag: -query-scheduler.ring.multi.mirror-timeout
-     *       [mirror_timeout: <duration> | default = 2s]
-     *
-     *   # Period at which to heartbeat to the ring. 0 = disabled.
-     *   # CLI flag: -query-scheduler.ring.heartbeat-period
-     *   [heartbeat_period: <duration> | default = 15s]
-     *
-     *   # The heartbeat timeout after which compactors are considered unhealthy within
-     *   # the ring. 0 = never (timeout disabled).
-     *   # CLI flag: -query-scheduler.ring.heartbeat-timeout
-     *   [heartbeat_timeout: <duration> | default = 1m]
-     *
-     *   # File path where tokens are stored. If empty, tokens are not stored at
-     *   # shutdown and restored at startup.
-     *   # CLI flag: -query-scheduler.ring.tokens-file-path
-     *   [tokens_file_path: <string> | default = ""]
-     *
-     *   # True to enable zone-awareness and replicate blocks across different
-     *   # availability zones.
-     *   # CLI flag: -query-scheduler.ring.zone-awareness-enabled
-     *   [zone_awareness_enabled: <boolean> | default = false]
-     *
-     *   # Instance ID to register in the ring.
-     *   # CLI flag: -query-scheduler.ring.instance-id
-     *   [instance_id: <string> | default = "<hostname>"]
-     *
-     *   # Name of network interface to read address from.
-     *   # CLI flag: -query-scheduler.ring.instance-interface-names
-     *   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
-     *
-     *   # Port to advertise in the ring (defaults to server.grpc-listen-port).
-     *   # CLI flag: -query-scheduler.ring.instance-port
-     *   [instance_port: <int> | default = 0]
-     *
-     *   # IP address to advertise in the ring.
-     *   # CLI flag: -query-scheduler.ring.instance-addr
-     *   [instance_addr: <string> | default = ""]
-     *
-     *   # The availability zone where this instance is running. Required if
-     *   # zone-awareness is enabled.
-     *   # CLI flag: -query-scheduler.ring.instance-availability-zone
-     *   [instance_availability_zone: <string> | default = ""]
-     *
-     *   # Enable using a IPv6 instance address.
-     *   # CLI flag: -query-scheduler.ring.instance-enable-ipv6
-     *   [instance_enable_ipv6: <boolean> | default = false]
      */
-) {
-}
+    val schedulerRing: queryScheduler.SchedulerRing? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/RuntimeConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/RuntimeConfig.kt
@@ -1,15 +1,21 @@
 package io.violabs.picard.starCharts.loki
 
-class RuntimeConfig(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class RuntimeConfig(
     /**
      * # How often to check runtime config files.
      * # CLI flag: -runtime-config.reload-period
      * [period: <duration> | default = 10s]
-     *
+     */
+    val period: Duration? = null,
+    /**
      * # Comma separated list of yaml files with the configuration that can be updated
      * # at runtime. Runtime config files will be merged from left to right.
      * # CLI flag: -runtime-config.file
      * [file: <string> | default = ""]
      */
-) {
-}
+    val file: String? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Tracing.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Tracing.kt
@@ -1,10 +1,13 @@
 package io.violabs.picard.starCharts.loki
 
-class Tracing(
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class Tracing(
     /**
      * # Set to false to disable tracing.
      * # CLI flag: -tracing.enabled
      * [enabled: <boolean> | default = true]
      */
-) {
-}
+    val enabled: Boolean? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Background.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Background.kt
@@ -1,0 +1,26 @@
+package io.violabs.picard.starCharts.loki.cacheConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+
+@GeneratedDSL
+data class Background(
+    /**
+     *   # At what concurrency to write back to cache.
+     *   # CLI flag: -<prefix>.background.write-back-concurrency
+     *   [writeback_goroutines: <int> | default = 1]
+     */
+    val writebackGoroutines: Int? = null,
+    /**
+     *   # How many key batches to buffer for background write-back. Default is large
+     *   # to prefer size based limiting.
+     *   # CLI flag: -<prefix>.background.write-back-buffer
+     *   [writeback_buffer: <int> | default = 500000]
+     */
+    val writebackBuffer: Int? = null,
+    /**
+     *   # Size limit in bytes for background write-back.
+     *   # CLI flag: -<prefix>.background.write-back-size-limit
+     *   [writeback_size_limit: <int> | default = 500MB]
+     */
+    val writebackSizeLimit: Int? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/EmbeddedCache.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/EmbeddedCache.kt
@@ -1,0 +1,32 @@
+package io.violabs.picard.starCharts.loki.cacheConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class EmbeddedCache(
+    /**
+     *   # Whether embedded cache is enabled.
+     *   # CLI flag: -<prefix>.embedded-cache.enabled
+     *   [enabled: <boolean> | default = false]
+     */
+    val enabled: Boolean? = null,
+    /**
+     *   # Maximum memory size of the cache in MB.
+     *   # CLI flag: -<prefix>.embedded-cache.max-size-mb
+     *   [max_size_mb: <int> | default = 100]
+     */
+    val maxSizeMb: Int? = null,
+    /**
+     *   # Maximum number of entries in the cache.
+     *   # CLI flag: -<prefix>.embedded-cache.max-size-items
+     *   [max_size_items: <int> | default = 0]
+     */
+    val maxSizeItems: Int? = null,
+    /**
+     *   # The time to live for items in the cache before they get purged.
+     *   # CLI flag: -<prefix>.embedded-cache.ttl
+     *   [ttl: <duration> | default = 1h]
+     */
+    val ttl: Duration? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Memcached.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Memcached.kt
@@ -1,0 +1,26 @@
+package io.violabs.picard.starCharts.loki.cacheConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class Memcached(
+    /**
+     *   # How long keys stay in the memcache.
+     *   # CLI flag: -<prefix>.memcached.expiration
+     *   [expiration: <duration> | default = 0s]
+     */
+    val expiration: Duration? = null,
+    /**
+     *   # How many keys to fetch in each batch.
+     *   # CLI flag: -<prefix>.memcached.batchsize
+     *   [batch_size: <int> | default = 4]
+     */
+    val batchSize: Int? = null,
+    /**
+     *   # Maximum active requests to memcache.
+     *   # CLI flag: -<prefix>.memcached.parallelism
+     *   [parallelism: <int> | default = 5]
+     */
+    val parallelism: Int? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/MemcachedClient.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/MemcachedClient.kt
@@ -1,0 +1,93 @@
+package io.violabs.picard.starCharts.loki.cacheConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+import io.violabs.picard.starCharts.loki.tls.TLSConfig
+
+@GeneratedDSL
+data class MemcachedClient(
+    /**
+     *   # Hostname for memcached service to use. If empty and if addresses is unset,
+     *   # no memcached will be used.
+     *   # CLI flag: -<prefix>.memcached.hostname
+     *   [host: <string> | default = ""]
+     */
+    val host: String? = null,
+    /**
+     *   # SRV service used to discover memcache servers.
+     *   # CLI flag: -<prefix>.memcached.service
+     *   [service: <string> | default = "memcached"]
+     */
+    val service: String? = null,
+    /**
+     *   # Comma separated addresses list in DNS Service Discovery format:
+     *   # https://grafana.com/docs/mimir/latest/configure/about-dns-service-discovery/#supported-discovery-modes
+     *   # CLI flag: -<prefix>.memcached.addresses
+     *   [addresses: <string> | default = ""]
+     */
+    val addresses: String? = null,
+    /**
+     *   # Maximum time to wait before giving up on memcached requests.
+     *   # CLI flag: -<prefix>.memcached.timeout
+     *   [timeout: <duration> | default = 100ms]
+     */
+    val timeout: Duration? = null,
+    /**
+     *   # Maximum number of idle connections in pool.
+     *   # CLI flag: -<prefix>.memcached.max-idle-conns
+     *   [max_idle_conns: <int> | default = 16]
+     */
+    val maxIdleConns: Int? = null,
+    /**
+     *   # The maximum size of an item stored in memcached. Bigger items are not
+     *   # stored. If set to 0, no maximum size is enforced.
+     *   # CLI flag: -<prefix>.memcached.max-item-size
+     *   [max_item_size: <int> | default = 0]
+     */
+    val maxItemSize: Int? = null,
+    /**
+     *   # Period with which to poll DNS for memcache servers.
+     *   # CLI flag: -<prefix>.memcached.update-interval
+     *   [update_interval: <duration> | default = 1m]
+     */
+    val updateInterval: Duration? = null,
+    /**
+     *   # Use consistent hashing to distribute to memcache servers.
+     *   # CLI flag: -<prefix>.memcached.consistent-hash
+     *   [consistent_hash: <boolean> | default = true]
+     */
+    val consistentHash: Boolean? = null,
+    /**
+     *   # Trip circuit-breaker after this number of consecutive dial failures (if zero
+     *   # then circuit-breaker is disabled).
+     *   # CLI flag: -<prefix>.memcached.circuit-breaker-consecutive-failures
+     *   [circuit_breaker_consecutive_failures: <int> | default = 10]
+     */
+    val circuitBreakerConsecutiveFailures: Int? = null,
+    /**
+     *   # Duration circuit-breaker remains open after tripping (if zero then 60
+     *   # seconds is used).
+     *   # CLI flag: -<prefix>.memcached.circuit-breaker-timeout
+     *   [circuit_breaker_timeout: <duration> | default = 10s]
+     */
+    val circuitBreakerTimeout: Duration? = null,
+    /**
+     *   # Reset circuit-breaker counts after this long (if zero then never reset).
+     *   # CLI flag: -<prefix>.memcached.circuit-breaker-interval
+     *   [circuit_breaker_interval: <duration> | default = 10s]
+     */
+    val circuitBreakerInterval: Duration? = null,
+    /**
+     *   # Enable connecting to Memcached with TLS.
+     *   # CLI flag: -<prefix>.memcached.tls-enabled
+     *   [tls_enabled: <boolean> | default = false]
+     */
+    val tlsEnabled: Boolean? = null,
+    /**
+     *   # The TLS configuration.
+     *   # The CLI flags prefix for this block configuration is:
+     *   # store.index-cache-write.memcached
+     *   [<tls_config>]
+     */
+    val tlsConfig: TLSConfig? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Redis.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cacheConfig/Redis.kt
@@ -1,0 +1,92 @@
+package io.violabs.picard.starCharts.loki.cacheConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class Redis(
+    /**
+     *   # Redis Server or Cluster configuration endpoint to use for caching. A
+     *   # comma-separated list of endpoints for Redis Cluster or Redis Sentinel. If
+     *   # empty, no redis will be used.
+     *   # CLI flag: -<prefix>.redis.endpoint
+     *   [endpoint: <string> | default = ""]
+     */
+    val endpoint: String? = null,
+    /**
+     *   # Redis Sentinel master name. An empty string for Redis Server or Redis Cluster.
+     *   # CLI flag: -<prefix>.redis.master-name
+     *   [master_name: <string> | default = ""]
+     */
+    val masterName: String? = null,
+    /**
+     *   # Maximum time to wait before giving up on redis requests.
+     *   # CLI flag: -<prefix>.redis.timeout
+     *   [timeout: <duration> | default = 500ms]
+     */
+    val timeout: Duration? = null,
+    /**
+     *   # How long keys stay in the redis.
+     *   # CLI flag: -<prefix>.redis.expiration
+     *   [expiration: <duration> | default = 0s]
+     */
+    val expiration: Duration? = null,
+    /**
+     *   # Database index.
+     *   # CLI flag: -<prefix>.redis.db
+     *   [db: <int> | default = 0]
+     */
+    val db: Int? = null,
+    /**
+     *   # Maximum number of connections in the pool.
+     *   # CLI flag: -<prefix>.redis.pool-size
+     *   [pool_size: <int> | default = 0]
+     */
+    val poolSize: Int? = null,
+    /**
+     *   # Username to use when connecting to redis.
+     *   # CLI flag: -<prefix>.redis.username
+     *   [username: <string> | default = ""]
+     */
+    val username: String? = null,
+    /**
+     *   # Password to use when connecting to redis.
+     *   # CLI flag: -<prefix>.redis.password
+     *   [password: <string> | default = ""]
+     */
+    val password: String? = null,
+    /**
+     *   # Enable connecting to redis with TLS.
+     *   # CLI flag: -<prefix>.redis.tls-enabled
+     *   [tls_enabled: <boolean> | default = false]
+     */
+    val tlsEnabled: Boolean? = null,
+    /**
+     *   # Skip validating server certificate.
+     *   # CLI flag: -<prefix>.redis.tls-insecure-skip-verify
+     *   [tls_insecure_skip_verify: <boolean> | default = false]
+     */
+    val tlsInsecureSkipVerify: Boolean? = null,
+    /**
+     *   # Close connections after remaining idle for this duration. If the value is
+     *   # zero, then idle connections are not closed.
+     *   # CLI flag: -<prefix>.redis.idle-timeout
+     *   [idle_timeout: <duration> | default = 0s]
+     */
+    val idleTimeout: Duration? = null,
+    /**
+     *   # Close connections older than this duration. If the value is zero, then the
+     *   # pool does not close connections based on age.
+     *   # CLI flag: -<prefix>.redis.max-connection-age
+     *   [max_connection_age: <duration> | default = 0s]
+     */
+    val maxConnectionAge: Duration? = null,
+    /**
+     *   # By default, the Redis client only reads from the master node. Enabling this
+     *   # option can lower pressure on the master node by randomly routing read-only
+     *   # commands to the master and any available replicas.
+     *   # CLI flag: -<prefix>.redis.route-randomly
+     *   [route_randomly: <boolean> | default = false]
+     */
+    val routeRandomly: Boolean? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cosStorageConfig/BackoffConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cosStorageConfig/BackoffConfig.kt
@@ -1,0 +1,26 @@
+package io.violabs.picard.starCharts.loki.cosStorageConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class BackoffConfig(
+    /**
+     *   # Minimum backoff time when cos get Object.
+     *   # CLI flag: -<prefix>.cos.min-backoff
+     *   [min_period: <duration> | default = 100ms]
+     */
+    val minPeriod: Duration? = null,
+    /**
+     *   # Maximum backoff time when cos get Object.
+     *   # CLI flag: -<prefix>.cos.max-backoff
+     *   [max_period: <duration> | default = 3s]
+     */
+    val maxPeriod: Duration? = null,
+    /**
+     *   # Maximum number of times to retry when cos get Object.
+     *   # CLI flag: -<prefix>.cos.max-retries
+     *   [max_retries: <int> | default = 5]
+     */
+    val maxRetries: Int? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cosStorageConfig/HTTPConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/cosStorageConfig/HTTPConfig.kt
@@ -1,0 +1,21 @@
+package io.violabs.picard.starCharts.loki.cosStorageConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class HTTPConfig(
+    /**
+     *   # The maximum amount of time an idle connection will be held open.
+     *   # CLI flag: -<prefix>.cos.http.idle-conn-timeout
+     *   [idle_conn_timeout: <duration> | default = 1m30s]
+     */
+    val idleConnTimeout: Duration? = null,
+    /**
+     *   # If non-zero, specifies the amount of time to wait for a server's response
+     *   # headers after fully writing the request.
+     *   # CLI flag: -<prefix>.cos.http.response-header-timeout
+     *   [response_header_timeout: <duration> | default = 0s]
+     */
+    val responseHeaderTimeout: Duration? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/indexGateway/Ring.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/indexGateway/Ring.kt
@@ -1,0 +1,142 @@
+package io.violabs.picard.starCharts.loki.indexGateway
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Consul
+import io.violabs.picard.starCharts.loki.ETCD
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class Ring(
+    val kvstore: KVStore? = null,
+    /**
+     *   # Period at which to heartbeat to the ring. 0 = disabled.
+     *   # CLI flag: -index-gateway.ring.heartbeat-period
+     *   [heartbeat_period: <duration> | default = 15s]
+     */
+    val heartbeatPeriod: Duration? = null,
+    /**
+     *   # The heartbeat timeout after which compactors are considered unhealthy within
+     *   # the ring. 0 = never (timeout disabled).
+     *   # CLI flag: -index-gateway.ring.heartbeat-timeout
+     *   [heartbeat_timeout: <duration> | default = 1m]
+     */
+    val heartbeatTimeout: Duration? = null,
+    /**
+     *   # File path where tokens are stored. If empty, tokens are not stored at
+     *   # shutdown and restored at startup.
+     *   # CLI flag: -index-gateway.ring.tokens-file-path
+     *   [tokens_file_path: <string> | default = ""]
+     */
+    val tokensFilePath: String? = null,
+    /**
+     *   # True to enable zone-awareness and replicate blocks across different
+     *   # availability zones.
+     *   # CLI flag: -index-gateway.ring.zone-awareness-enabled
+     *   [zone_awareness_enabled: <boolean> | default = false]
+     */
+    val zoneAwarenessEnabled: Boolean? = null,
+    /**
+     *   # Deprecated: How many index gateway instances are assigned to each tenant.
+     *   # Use -index-gateway.shard-size instead.
+     *   # CLI flag: -replication-factor
+     *   [replication_factor: <int> | default = 3]
+     */
+    val replicationFactor: Int? = null,
+    /**
+     *   # Instance ID to register in the ring.
+     *   # CLI flag: -index-gateway.ring.instance-id
+     *   [instance_id: <string> | default = "<hostname>"]
+     */
+    val instanceId: String? = null,
+    /**
+     *   # Name of network interface to read address from.
+     *   # CLI flag: -index-gateway.ring.instance-interface-names
+     *   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
+     */
+    val instanceInterfaceNames: List<String>? = null,
+    /**
+     *   # Port to advertise in the ring (defaults to server.grpc-listen-port).
+     *   # CLI flag: -index-gateway.ring.instance-port
+     *   [instance_port: <int> | default = 0]
+     */
+    val instancePort: Int? = null,
+    /**
+     *   # IP address to advertise in the ring.
+     *   # CLI flag: -index-gateway.ring.instance-addr
+     *   [instance_addr: <string> | default = ""]
+     */
+    val instanceAddr: String? = null,
+    /**
+     *   # The availability zone where this instance is running. Required if
+     *   # zone-awareness is enabled.
+     *   # CLI flag: -index-gateway.ring.instance-availability-zone
+     *   [instance_availability_zone: <string> | default = ""]
+     */
+    val instanceAvailabilityZone: String? = null,
+    /**
+     *   # Enable using a IPv6 instance address.
+     *   # CLI flag: -index-gateway.ring.instance-enable-ipv6
+     *   [instance_enable_ipv6: <boolean> | default = false]
+     */
+    val instanceEnableIpv6: Boolean? = null,
+) {
+    @GeneratedDSL
+    data class KVStore(
+        /**
+         *     # Backend storage to use for the ring. Supported values are: consul, etcd,
+         *     # inmemory, memberlist, multi.
+         *     # CLI flag: -index-gateway.ring.store
+         *     [store: <string> | default = "consul"]
+         */
+        val store: String? = null,
+        /**
+         *     # The prefix for the keys in the store. Should end with a /.
+         *     # CLI flag: -index-gateway.ring.prefix
+         *     [prefix: <string> | default = "collectors/"]
+         */
+        val prefix: String? = null,
+        /**
+         *     # Configuration for a Consul client. Only applies if the selected kvstore is
+         *     # consul.
+         *     # The CLI flags prefix for this block configuration is: index-gateway.ring
+         *     [consul: <consul>]
+         */
+        val consul: Consul? = null,
+        /**
+         *     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+         *     # is etcd.
+         *     # The CLI flags prefix for this block configuration is: index-gateway.ring
+         *     [etcd: <etcd>]
+         */
+        val etcd: ETCD? = null,
+        val multi: Multi? = null,
+    ) {
+        @GeneratedDSL
+        data class Multi(
+            /**
+             *       # Primary backend storage used by multi-client.
+             *       # CLI flag: -index-gateway.ring.multi.primary
+             *       [primary: <string> | default = ""]
+             */
+            val primary: String? = null,
+            /**
+             *       # Secondary backend storage used by multi-client.
+             *       # CLI flag: -index-gateway.ring.multi.secondary
+             *       [secondary: <string> | default = ""]
+             */
+            val secondary: String? = null,
+            /**
+             *       # Mirror writes to secondary store.
+             *       # CLI flag: -index-gateway.ring.multi.mirror-enabled
+             *       [mirror_enabled: <boolean> | default = false]
+             */
+            val mirrorEnabled: Boolean? = null,
+            /**
+             *       # Timeout for storing value to secondary store.
+             *       # CLI flag: -index-gateway.ring.multi.mirror-timeout
+             *       [mirror_timeout: <duration> | default = 2s]
+             */
+            val mirrorTimeout: Duration? = null,
+        )
+    }
+}

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/queryScheduler/SchedulerRing.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/queryScheduler/SchedulerRing.kt
@@ -1,0 +1,135 @@
+package io.violabs.picard.starCharts.loki.queryScheduler
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Consul
+import io.violabs.picard.starCharts.loki.ETCD
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class SchedulerRing(
+    val kvstore: KVStore? = null,
+    /**
+     *   # Period at which to heartbeat to the ring. 0 = disabled.
+     *   # CLI flag: -query-scheduler.ring.heartbeat-period
+     *   [heartbeat_period: <duration> | default = 15s]
+     */
+    val heartbeatPeriod: Duration? = null,
+    /**
+     *   # The heartbeat timeout after which compactors are considered unhealthy within
+     *   # the ring. 0 = never (timeout disabled).
+     *   # CLI flag: -query-scheduler.ring.heartbeat-timeout
+     *   [heartbeat_timeout: <duration> | default = 1m]
+     */
+    val heartbeatTimeout: Duration? = null,
+    /**
+     *   # File path where tokens are stored. If empty, tokens are not stored at
+     *   # shutdown and restored at startup.
+     *   # CLI flag: -query-scheduler.ring.tokens-file-path
+     *   [tokens_file_path: <string> | default = ""]
+     */
+    val tokensFilePath: String? = null,
+    /**
+     *   # True to enable zone-awareness and replicate blocks across different
+     *   # availability zones.
+     *   # CLI flag: -query-scheduler.ring.zone-awareness-enabled
+     *   [zone_awareness_enabled: <boolean> | default = false]
+     */
+    val zoneAwarenessEnabled: Boolean? = null,
+    /**
+     *   # Instance ID to register in the ring.
+     *   # CLI flag: -query-scheduler.ring.instance-id
+     *   [instance_id: <string> | default = "<hostname>"]
+     */
+    val instanceId: String? = null,
+    /**
+     *   # Name of network interface to read address from.
+     *   # CLI flag: -query-scheduler.ring.instance-interface-names
+     *   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
+     */
+    val instanceInterfaceNames: List<String>? = null,
+    /**
+     *   # Port to advertise in the ring (defaults to server.grpc-listen-port).
+     *   # CLI flag: -query-scheduler.ring.instance-port
+     *   [instance_port: <int> | default = 0]
+     */
+    val instancePort: Int? = null,
+    /**
+     *   # IP address to advertise in the ring.
+     *   # CLI flag: -query-scheduler.ring.instance-addr
+     *   [instance_addr: <string> | default = ""]
+     */
+    val instanceAddr: String? = null,
+    /**
+     *   # The availability zone where this instance is running. Required if
+     *   # zone-awareness is enabled.
+     *   # CLI flag: -query-scheduler.ring.instance-availability-zone
+     *   [instance_availability_zone: <string> | default = ""]
+     */
+    val instanceAvailabilityZone: String? = null,
+    /**
+     *   # Enable using a IPv6 instance address.
+     *   # CLI flag: -query-scheduler.ring.instance-enable-ipv6
+     *   [instance_enable_ipv6: <boolean> | default = false]
+     */
+    val instanceEnableIpv6: Boolean? = null,
+) {
+    @GeneratedDSL
+    data class KVStore(
+        /**
+         *     # Backend storage to use for the ring. Supported values are: consul, etcd,
+         *     # inmemory, memberlist, multi.
+         *     # CLI flag: -query-scheduler.ring.store
+         *     [store: <string> | default = "consul"]
+         */
+        val store: String? = null,
+        /**
+         *     # The prefix for the keys in the store. Should end with a /.
+         *     # CLI flag: -query-scheduler.ring.prefix
+         *     [prefix: <string> | default = "collectors/"]
+         */
+        val prefix: String? = null,
+        /**
+         *     # Configuration for a Consul client. Only applies if the selected kvstore is
+         *     # consul.
+         *     # The CLI flags prefix for this block configuration is: query-scheduler.ring
+         *     [consul: <consul>]
+         */
+        val consul: Consul? = null,
+        /**
+         *     # Configuration for an ETCD v3 client. Only applies if the selected kvstore
+         *     # is etcd.
+         *     # The CLI flags prefix for this block configuration is: query-scheduler.ring
+         *     [etcd: <etcd>]
+         */
+        val etcd: ETCD? = null,
+        val multi: Multi? = null,
+    ) {
+        @GeneratedDSL
+        data class Multi(
+            /**
+             *       # Primary backend storage used by multi-client.
+             *       # CLI flag: -query-scheduler.ring.multi.primary
+             *       [primary: <string> | default = ""]
+             */
+            val primary: String? = null,
+            /**
+             *       # Secondary backend storage used by multi-client.
+             *       # CLI flag: -query-scheduler.ring.multi.secondary
+             *       [secondary: <string> | default = ""]
+             */
+            val secondary: String? = null,
+            /**
+             *       # Mirror writes to secondary store.
+             *       # CLI flag: -query-scheduler.ring.multi.mirror-enabled
+             *       [mirror_enabled: <boolean> | default = false]
+             */
+            val mirrorEnabled: Boolean? = null,
+            /**
+             *       # Timeout for storing value to secondary store.
+             *       # CLI flag: -query-scheduler.ring.multi.mirror-timeout
+             *       [mirror_timeout: <duration> | default = 2s]
+             */
+            val mirrorTimeout: Duration? = null,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- implement structured properties for `CacheConfig`, `ChunkStorageConfig`, `IndexGateway`, and `QueryScheduler`
- create nested configuration data classes for cache, index gateway ring, and query scheduler ring
- remove accidental `.gradle` artefacts and ignore future ones

## Testing
- `./gradlew build` *(fails: Could not resolve dependencies)*