### PR TITLE
Fill missing Loki properties

### DIFF
--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/GRPCClient.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/GRPCClient.kt
@@ -1,32 +1,51 @@
 package io.violabs.picard.starCharts.loki
 
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+import io.violabs.picard.starCharts.loki.tls.TLSConfig
+import io.violabs.picard.starCharts.loki.clusterValidation.ClusterValidation
+import io.violabs.picard.starCharts.loki.grpcClient.backoffConfig.BackoffConfig
+
+@GeneratedDSL
 class GRPCClient(
     /**
      * # gRPC client max receive message size (bytes).
      * # CLI flag: -<prefix>.grpc-max-recv-msg-size
      * [max_recv_msg_size: <int> | default = 104857600]
-     *
+     */
+    val maxRecvMsgSize: Int? = null,
+    /**
      * # gRPC client max send message size (bytes).
      * # CLI flag: -<prefix>.grpc-max-send-msg-size
      * [max_send_msg_size: <int> | default = 104857600]
-     *
+     */
+    val maxSendMsgSize: Int? = null,
+    /**
      * # Use compression when sending messages. Supported values are: 'gzip', 'snappy'
      * # and '' (disable compression)
      * # CLI flag: -<prefix>.grpc-compression
      * [grpc_compression: <string> | default = ""]
-     *
+     */
+    val grpcCompression: String? = null,
+    /**
      * # Rate limit for gRPC client; 0 means disabled.
      * # CLI flag: -<prefix>.grpc-client-rate-limit
      * [rate_limit: <float> | default = 0]
-     *
+     */
+    val rateLimit: Float? = null,
+    /**
      * # Rate limit burst for gRPC client.
      * # CLI flag: -<prefix>.grpc-client-rate-limit-burst
      * [rate_limit_burst: <int> | default = 0]
-     *
+     */
+    val rateLimitBurst: Int? = null,
+    /**
      * # Enable backoff and retry when we hit rate limits.
      * # CLI flag: -<prefix>.backoff-on-ratelimits
      * [backoff_on_ratelimits: <boolean> | default = false]
-     *
+     */
+    val backoffOnRatelimits: Boolean? = null,
+    /**
      * backoff_config:
      *   # Minimum delay when backing off.
      *   # CLI flag: -<prefix>.backoff-min-period
@@ -39,49 +58,65 @@ class GRPCClient(
      *   # Number of times to backoff and retry before failing.
      *   # CLI flag: -<prefix>.backoff-retries
      *   [max_retries: <int> | default = 10]
-     *
+     */
+    val backoffConfig: BackoffConfig? = null,
+    /**
      * # Initial stream window size. Values less than the default are not supported and
      * # are ignored. Setting this to a value other than the default disables the BDP
      * # estimator.
      * # CLI flag: -<prefix>.initial-stream-window-size
      * [initial_stream_window_size: <int> | default = 63KiB1023B]
-     *
+     */
+    val initialStreamWindowSize: Int? = null,
+    /**
      * # Initial connection window size. Values less than the default are not supported
      * # and are ignored. Setting this to a value other than the default disables the
      * # BDP estimator.
      * # CLI flag: -<prefix>.initial-connection-window-size
      * [initial_connection_window_size: <int> | default = 63KiB1023B]
-     *
+     */
+    val initialConnectionWindowSize: Int? = null,
+    /**
      * # Enable TLS in the gRPC client. This flag needs to be enabled when any other
      * # TLS flag is set. If set to false, insecure connection to gRPC server will be
      * # used.
      * # CLI flag: -<prefix>.tls-enabled
      * [tls_enabled: <boolean> | default = false]
-     *
+     */
+    val tlsEnabled: Boolean? = null,
+    /**
      * # The TLS configuration.
      * # The CLI flags prefix for this block configuration is:
      * # tsdb.shipper.index-gateway-client.grpc
      * [<tls_config>]
-     *
+     */
+    val tlsConfig: TLSConfig? = null,
+    /**
      * # The maximum amount of time to establish a connection. A value of 0 means
      * # default gRPC client connect timeout and backoff.
      * # CLI flag: -<prefix>.connect-timeout
      * [connect_timeout: <duration> | default = 5s]
-     *
+     */
+    val connectTimeout: Duration? = null,
+    /**
      * # Initial backoff delay after first connection failure. Only relevant if
      * # ConnectTimeout > 0.
      * # CLI flag: -<prefix>.connect-backoff-base-delay
      * [connect_backoff_base_delay: <duration> | default = 1s]
-     *
+     */
+    val connectBackoffBaseDelay: Duration? = null,
+    /**
      * # Maximum backoff delay when establishing a connection. Only relevant if
      * # ConnectTimeout > 0.
      * # CLI flag: -<prefix>.connect-backoff-max-delay
      * [connect_backoff_max_delay: <duration> | default = 5s]
-     *
+     */
+    val connectBackoffMaxDelay: Duration? = null,
+    /**
      * cluster_validation:
      *   # Optionally define the cluster validation label.
      *   # CLI flag: -<prefix>.cluster-validation.label
      *   [label: <string> | default = ""]
      */
-) {
-}
+    val clusterValidation: ClusterValidation? = null,
+)

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Profiling.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/Profiling.kt
@@ -6,15 +6,18 @@ class Profiling(
      * # CLI flag: -profiling.block-profile-rate
      * [block_profile_rate: <int> | default = 0]
      */
+    val blockProfileRate: Int? = null,
     /**
      * # Sets the value for runtime.SetCPUProfileRate
      * # CLI flag: -profiling.cpu-profile-rate
      * [cpu_profile_rate: <int> | default = 0]
      */
+    val cpuProfileRate: Int? = null,
     /**
      * # Sets the value for runtime.SetMutexProfileFraction
      * # CLI flag: -profiling.mutex-profile-fraction
      * [mutex_profile_fraction: <int> | default = 0]
      */
+    val mutexProfileFraction: Int? = null,
 ) {
 }

--- a/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/grpcClient/backoffConfig/BackoffConfig.kt
+++ b/star-charts/loki/src/main/kotlin/io/violabs/picard/starCharts/loki/grpcClient/backoffConfig/BackoffConfig.kt
@@ -1,0 +1,26 @@
+package io.violabs.picard.starCharts.loki.grpcClient.backoffConfig
+
+import io.violabs.picard.dsl.annotation.GeneratedDSL
+import io.violabs.picard.starCharts.loki.Duration
+
+@GeneratedDSL
+data class BackoffConfig(
+    /**
+     *   # Minimum delay when backing off.
+     *   # CLI flag: -<prefix>.backoff-min-period
+     *   [min_period: <duration> | default = 100ms]
+     */
+    val minPeriod: Duration? = null,
+    /**
+     *   # Maximum delay when backing off.
+     *   # CLI flag: -<prefix>.backoff-max-period
+     *   [max_period: <duration> | default = 10s]
+     */
+    val maxPeriod: Duration? = null,
+    /**
+     *   # Number of times to backoff and retry before failing.
+     *   # CLI flag: -<prefix>.backoff-retries
+     *   [max_retries: <int> | default = 10]
+     */
+    val maxRetries: Int? = null,
+)


### PR DESCRIPTION
## Summary
- implement remaining Loki DSL fields for `Profiling`
- flesh out `GRPCClient` with properties and nested `BackoffConfig`
- create new `grpcClient.backoffConfig.BackoffConfig`

## Testing
- `./gradlew test` *(fails: could not resolve dependencies)*