### PR TITLE
Add LimitRange V2 resource and tests

### DIFF
--- a/core/src/main/kotlin/io/violabs/picard/domain/k8sResources/APIVersion.kt
+++ b/core/src/main/kotlin/io/violabs/picard/domain/k8sResources/APIVersion.kt
@@ -146,6 +146,8 @@ import io.violabs.picard.v2.resources.authorization.role.binding.RoleBindingV2
 import io.violabs.picard.v2.resources.config.map.ConfigMapV2
 import io.violabs.picard.v2.resources.config.secret.SecretV2
 import io.violabs.picard.v2.resources.policy.schema.flow.FlowSchemaV2
+import io.violabs.picard.v2.resources.policy.limitRange.LimitRangeV2
+import io.violabs.picard.v2.resources.policy.limitRange.LimitRangeListV2
 import io.violabs.picard.v2.resources.storage.StorageClassV2
 import io.violabs.picard.v2.resources.storage.version.migration.StorageVersionMigrationV2
 import io.violabs.picard.v2.resources.storage.persistent.volume.claim.PersistentVolumeClaimV2
@@ -178,6 +180,8 @@ open class KAPIVersion(
         EndpointsList.Version,
         LimitRange.Version,
         LimitRangeList.Version,
+        LimitRangeV2.Version,
+        LimitRangeListV2.Version,
         Namespace.Version,
         NamespaceList.Version,
         Node.Version,

--- a/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeItem.kt
+++ b/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeItem.kt
@@ -1,0 +1,25 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+import io.violabs.konstellation.metaDsl.annotation.GeneratedDsl
+import io.violabs.picard.domain.k8sResources.Quantity
+
+/**
+ * Item that holds the min/max/default resource constraints for a particular type.
+ */
+@GeneratedDsl(withListGroup = true)
+data class LimitRangeItem(
+    /**
+     * Type of resource that the limits apply to.
+     */
+    val type: String,
+    /** default resource values enforced. */
+    val default: Map<String, Quantity>? = null,
+    /** default request values enforced. */
+    val defaultRequest: Map<String, Quantity>? = null,
+    /** maximum allowed usage. */
+    val max: Map<String, Quantity>? = null,
+    /** maxLimitRequestRatio specifies limit-to-request ratio. */
+    val maxLimitRequestRatio: Map<String, Quantity>? = null,
+    /** minimum allowed usage. */
+    val min: Map<String, Quantity>? = null,
+)

--- a/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeListV2.kt
+++ b/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeListV2.kt
@@ -1,0 +1,26 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+import io.violabs.konstellation.metaDsl.annotation.DefaultValue
+import io.violabs.konstellation.metaDsl.annotation.GeneratedDsl
+import io.violabs.picard.common.AppConstants
+import io.violabs.picard.domain.ListMeta
+import io.violabs.picard.domain.k8sResources.APIVersion
+import io.violabs.picard.domain.k8sResources.KAPIVersion
+import io.violabs.picard.domain.manifest.PolicyListResource
+
+/**
+ * List of LimitRange resources.
+ */
+@GeneratedDsl
+data class LimitRangeListV2(
+    @DefaultValue(
+        "KAPIVersion.V1",
+        AppConstants.DefaultValue.KAPI_VERSION_PACKAGE,
+        AppConstants.DefaultValue.KAPI_VERSION_CLASS
+    )
+    override val apiVersion: Version = KAPIVersion.V1,
+    override val items: List<LimitRangeV2>,
+    override val metadata: ListMeta? = null,
+) : PolicyListResource<LimitRangeListV2.Version, LimitRangeV2> {
+    interface Version : APIVersion
+}

--- a/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeSpec.kt
+++ b/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeSpec.kt
@@ -1,0 +1,14 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+import io.violabs.konstellation.metaDsl.annotation.GeneratedDsl
+
+/**
+ * Specification for a LimitRange.
+ */
+@GeneratedDsl
+data class LimitRangeSpec(
+    /**
+     * List of limits that apply to resources.
+     */
+    val limits: List<LimitRangeItem>,
+)

--- a/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeV2.kt
+++ b/core/src/main/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeV2.kt
@@ -1,0 +1,32 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+import io.violabs.konstellation.metaDsl.annotation.DefaultValue
+import io.violabs.konstellation.metaDsl.annotation.GeneratedDsl
+import io.violabs.picard.common.AppConstants
+import io.violabs.picard.domain.k8sResources.APIVersion
+import io.violabs.picard.domain.k8sResources.KAPIVersion
+import io.violabs.picard.domain.manifest.PolicyResource
+import io.violabs.picard.v2.common.ObjectMeta
+
+/**
+ * https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/limit-range-v1/
+ *
+ * LimitRange sets resource usage limits for each kind of resource in a Namespace.
+ * apiVersion: v1
+ */
+@GeneratedDsl
+data class LimitRangeV2(
+    @DefaultValue(
+        "KAPIVersion.V1",
+        AppConstants.DefaultValue.KAPI_VERSION_PACKAGE,
+        AppConstants.DefaultValue.KAPI_VERSION_CLASS
+    )
+    override val apiVersion: Version = KAPIVersion.V1,
+    override val metadata: ObjectMeta? = null,
+    /**
+     * Specification of the desired limits to enforce.
+     */
+    val spec: LimitRangeSpec? = null,
+) : PolicyResource<LimitRangeV2.Version, ObjectMeta> {
+    interface Version : APIVersion
+}

--- a/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeItemTest.kt
+++ b/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeItemTest.kt
@@ -1,0 +1,23 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+
+import io.violabs.picard.FailureBuildSim
+import io.violabs.picard.possibilities
+import org.junit.jupiter.api.BeforeAll
+
+class LimitRangeItemTest : FailureBuildSim<LimitRangeItem, LimitRangeItemDslBuilder>() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setup() = buildSetup(
+            LimitRangeItemTest::class,
+            failureScenariosSet = FAILURE_POSSIBILITIES
+        )
+
+        private val FAILURE_POSSIBILITIES = possibilities<LimitRangeItem, LimitRangeItemDslBuilder> {
+            requireScenario("type") {
+                given(LimitRangeItemDslBuilder())
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeListTest.kt
+++ b/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeListTest.kt
@@ -1,0 +1,36 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+
+import io.violabs.picard.FullBuildSim
+import io.violabs.picard.possibilities
+import org.junit.jupiter.api.BeforeAll
+
+class LimitRangeListTest : FullBuildSim<LimitRangeListV2, LimitRangeListV2DslBuilder>() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setup() = buildSetup(
+            LimitRangeListTest::class,
+            SUCCESS_POSSIBILITIES,
+            FAILURE_POSSIBILITIES
+        )
+
+        private val SUCCESS_POSSIBILITIES = possibilities<LimitRangeListV2, LimitRangeListV2DslBuilder> {
+            scenario {
+                id = "minimum"
+                given(LimitRangeListV2DslBuilder()) {
+                    items(LimitRangeV2())
+                }
+                expected = LimitRangeListV2(
+                    items = listOf(LimitRangeV2())
+                )
+            }
+        }
+
+        private val FAILURE_POSSIBILITIES = possibilities<LimitRangeListV2, LimitRangeListV2DslBuilder> {
+            requireNotEmptyScenario("items") {
+                given(LimitRangeListV2DslBuilder())
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeSpecTest.kt
+++ b/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeSpecTest.kt
@@ -1,0 +1,23 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+
+import io.violabs.picard.FailureBuildSim
+import io.violabs.picard.possibilities
+import org.junit.jupiter.api.BeforeAll
+
+class LimitRangeSpecTest : FailureBuildSim<LimitRangeSpec, LimitRangeSpecDslBuilder>() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setup() = buildSetup(
+            LimitRangeSpecTest::class,
+            failureScenariosSet = FAILURE_POSSIBILITIES
+        )
+
+        private val FAILURE_POSSIBILITIES = possibilities<LimitRangeSpec, LimitRangeSpecDslBuilder> {
+            requireScenario("limits") {
+                given(LimitRangeSpecDslBuilder())
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeTest.kt
+++ b/core/src/test/kotlin/io/violabs/picard/v2/resources/policy/limitRange/LimitRangeTest.kt
@@ -1,0 +1,64 @@
+package io.violabs.picard.v2.resources.policy.limitRange
+
+
+import io.violabs.picard.Common
+import io.violabs.picard.Common.sharedObjectMeta
+import io.violabs.picard.SuccessBuildSim
+import io.violabs.picard.possibilities
+import org.junit.jupiter.api.BeforeAll
+
+class LimitRangeTest : SuccessBuildSim<LimitRangeV2, LimitRangeV2DslBuilder>() {
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setup() = buildSetup(
+            LimitRangeTest::class,
+            SUCCESS_POSSIBILITIES
+        )
+
+
+        private val SUCCESS_POSSIBILITIES = possibilities<LimitRangeV2, LimitRangeV2DslBuilder> {
+            scenario {
+                id = "minimum"
+                given(LimitRangeV2DslBuilder())
+                expected = LimitRangeV2()
+            }
+
+            scenario {
+                id = "full"
+                given(LimitRangeV2DslBuilder()) {
+                    metadata {
+                        sharedObjectMeta()
+                    }
+                    spec {
+                        limits {
+                            limitRangeItem {
+                                type = PLACEHOLDER
+                                default(QUANTITY_PAIR)
+                                defaultRequest(QUANTITY_PAIR)
+                                max(QUANTITY_PAIR)
+                                maxLimitRequestRatio(QUANTITY_PAIR)
+                                min(QUANTITY_PAIR)
+                            }
+                        }
+                    }
+                }
+                expected = LimitRangeV2(
+                    metadata = Common.OBJECT_META,
+                    spec = LimitRangeSpec(
+                        limits = listOf(
+                            LimitRangeItem(
+                                type = PLACEHOLDER,
+                                default = QUANTITY_MAP,
+                                defaultRequest = QUANTITY_MAP,
+                                max = QUANTITY_MAP,
+                                maxLimitRequestRatio = QUANTITY_MAP,
+                                min = QUANTITY_MAP
+                            )
+                        )
+                    )
+                )
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/violabs/picard/v2/resources/storage/csi/storage/capacity/CSIStorageCapacityTest.kt
+++ b/core/src/test/kotlin/io/violabs/picard/v2/resources/storage/csi/storage/capacity/CSIStorageCapacityTest.kt
@@ -4,6 +4,7 @@ package io.violabs.picard.v2.resources.storage.csi.storage.capacity
 import io.violabs.picard.Common
 import io.violabs.picard.Common.sharedObjectMeta
 import io.violabs.picard.Common.sharedSelector
+import io.violabs.picard.BuildSim.Companion.QUANTITY
 import io.violabs.picard.FullBuildSim
 import io.violabs.picard.possibilities
 import org.junit.jupiter.api.BeforeAll
@@ -35,8 +36,8 @@ class CSIStorageCapacityTest : FullBuildSim<CsiStorageCapacityV2, CsiStorageCapa
                     }
 
                     storageClassName = PLACEHOLDER
-                    capacity(PLACEHOLDER)
-                    maximumVolumeSize(PLACEHOLDER)
+                    capacity = QUANTITY
+                    maximumVolumeSize = QUANTITY
                     nodeTopology {
                         sharedSelector()
                     }


### PR DESCRIPTION
## Summary
- implement LimitRange V2 resource models
- support LimitRange V2 in `APIVersion`
- provide new DSL tests for LimitRange V2
- fix CSIStorageCapacity test

## Testing
- `./gradlew test --no-daemon --stacktrace`

------
https://chatgpt.com/codex/tasks/task_e_6886bf792fec832ca4b81c2660c4b1f3